### PR TITLE
Add functionality for tracking record modification

### DIFF
--- a/asaps/models.py
+++ b/asaps/models.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import attr
 from functools import partial
@@ -90,6 +91,16 @@ class BaseRecord:
     old_value = Field()
     new_value = Field()
 
+    def __attrs_post_init__(self):
+        self.__update_hash__()
+
+    def __update_hash__(self):
+        self.__record_hash__ = hash_record(self)
+
+    @property
+    def modified(self):
+        return self.__record_hash__ != hash_record(self)
+
 
 @attr.s
 class Resource(BaseRecord):
@@ -108,6 +119,11 @@ class ArchivalObject(BaseRecord):
     ref_id = Field()
     parent = Field()
     resource = Field()
+
+
+def hash_record(record):
+    return hashlib.sha1(json.dumps(attr.asdict(record), ensure_ascii=False,
+                                   sort_keys=True).encode("utf-8")).digest()
 
 
 # output functions

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,6 +22,13 @@ def test_get_record(as_ops):
         assert response.json_string == json_object
 
 
+def test_record_is_modified():
+    record = models.Resource()
+    assert not record.modified
+    record.title = "I am different"
+    assert record.modified
+
+
 def test_search():
     """Test search method."""
     assert False


### PR DESCRIPTION
This seems like the easiest, least intrusive way of dealing with
tracking when a record has been changed. The goal is to avoid making a
bunch of POST requests for records that may not necessarily be modified
when running batch edits.

#### Includes new or updated dependencies?
NO
