### PR TITLE
get all records method

### DIFF
--- a/asaps/cli.py
+++ b/asaps/cli.py
@@ -25,10 +25,12 @@ def main(url, username, password):
     note_type = 'prefercite'
     old = 'the'
     new = 'that'
-    ids, endpoint = as_ops.get_all_records(rec_type, repo_id)
+    endpoint = as_ops.create_endpoint(rec_type, repo_id)
+    ids = as_ops.get_all_records(endpoint)
     print(ids)
     for id in ids:
         uri = f'{endpoint}/{id}'
+        print(uri)
         rec_obj = as_ops.get_record(uri)
         rec_obj = models.filter_note_type(as_ops, csv_data,
                                           rec_obj, note_type,

--- a/asaps/cli.py
+++ b/asaps/cli.py
@@ -19,61 +19,77 @@ def main(url, username, password):
     as_ops = models.AsOperations(client)
     start_time = time.time()
 
-    rec_types = ['resource', 'archival_object']
-    corr_dict = {'IASC': 'DDC'}
-    # corr_dict = {'Institute Archives and Special Collections':
-    #              'Department of Distinctive Collections'}
-    # corr_dict = {'the Institute Archives': 'Distinctive Collections'}
-    # corr_dict = {'Institute Archives': 'Distinctive Collections'}
-    # corr_dict = {'IASC': 'DDC',
-    #              'Institute Archives and Special Collections':
-    #              'Department of Distinctive Collections',
-    #              'the Institute Archives': 'Distinctive Collections'}  # ,
-    #              # 'Institute Archives': 'Distinctive Collections'}
-
-    error_uris = ['/repositories/2/resources/424',
-                  '/repositories/2/resources/1233',
-                  '/repositories/2/resources/377',
-                  '/repositories/2/resources/356',
-                  '/repositories/2/resources/228',
-                  '/repositories/2/resources/658',
-                  '/repositories/2/resources/635',
-                  '/repositories/2/resources/704',
-                  '/repositories/2/resources/202',
-                  '/repositories/2/resources/586']
-
-    skipped_resources = ['/repositories/2/resources/535',
-                         '/repositories/2/resources/41',
-                         '/repositories/2/resources/111',
-                         '/repositories/2/resources/367',
-                         '/repositories/2/resources/231',
-                         '/repositories/2/resources/561',
-                         '/repositories/2/resources/563',
-                         '/repositories/2/resources/103']
-    skipped_aos = []
-    for uri in skipped_resources:
-        aolist = as_ops.get_aos_for_resource(uri)
-        skipped_aos.append(aolist)
-    skipped_uris = error_uris + skipped_resources + skipped_aos
     csv_data = []
-    note_types = ['userestrict', 'acqinfo']
-    counter = 0
-    for rec_type in rec_types:
-        for old, new in corr_dict.items():
-            results = as_ops.search(old, '2', rec_type)
-            for result in results:
-                counter += 1
-                uri = result['uri']
-                if uri not in skipped_uris:
-                    for note_type in note_types:
-                        print(old, rec_type, note_type, counter)
-                        rec_obj = as_ops.get_record(uri)
-                        rec_obj = models.filter_note_type(as_ops, csv_data,
-                                                          rec_obj, note_type,
-                                                          'find_replace_test',
-                                                          old, new)
-            else:
-                print(uri, ' skipped')
+    rec_type = 'resource'
+    repo_id = '2'
+    note_type = 'prefercite'
+    old = 'the'
+    new = 'that'
+    ids, endpoint = as_ops.get_all_records(rec_type, repo_id)
+    print(ids)
+    for id in ids:
+        uri = f'{endpoint}/{id}'
+        rec_obj = as_ops.get_record(uri)
+        rec_obj = models.filter_note_type(as_ops, csv_data,
+                                          rec_obj, note_type,
+                                          'find_replace_test',
+                                          old, new)
+
+    # rec_types = ['resource', 'archival_object']
+    # corr_dict = {'IASC': 'DDC'}
+    # # corr_dict = {'Institute Archives and Special Collections':
+    # #              'Department of Distinctive Collections'}
+    # # corr_dict = {'the Institute Archives': 'Distinctive Collections'}
+    # # corr_dict = {'Institute Archives': 'Distinctive Collections'}
+    # # corr_dict = {'IASC': 'DDC',
+    # #              'Institute Archives and Special Collections':
+    # #              'Department of Distinctive Collections',
+    # #              'the Institute Archives': 'Distinctive Collections'}  # ,
+    # #              # 'Institute Archives': 'Distinctive Collections'}
+    #
+    # error_uris = ['/repositories/2/resources/424',
+    #               '/repositories/2/resources/1233',
+    #               '/repositories/2/resources/377',
+    #               '/repositories/2/resources/356',
+    #               '/repositories/2/resources/228',
+    #               '/repositories/2/resources/658',
+    #               '/repositories/2/resources/635',
+    #               '/repositories/2/resources/704',
+    #               '/repositories/2/resources/202',
+    #               '/repositories/2/resources/586']
+    #
+    # skipped_resources = ['/repositories/2/resources/535',
+    #                      '/repositories/2/resources/41',
+    #                      '/repositories/2/resources/111',
+    #                      '/repositories/2/resources/367',
+    #                      '/repositories/2/resources/231',
+    #                      '/repositories/2/resources/561',
+    #                      '/repositories/2/resources/563',
+    #                      '/repositories/2/resources/103']
+    # skipped_aos = []
+    # for uri in skipped_resources:
+    #     aolist = as_ops.get_aos_for_resource(uri)
+    #     skipped_aos.append(aolist)
+    # skipped_uris = error_uris + skipped_resources + skipped_aos
+    # csv_data = []
+    # note_types = ['userestrict', 'acqinfo']
+    # counter = 0
+    # for rec_type in rec_types:
+    #     for old, new in corr_dict.items():
+    #         results = as_ops.search(old, '2', rec_type)
+    #         for result in results:
+    #             counter += 1
+    #             uri = result['uri']
+    #             if uri not in skipped_uris:
+    #                 for note_type in note_types:
+    #                     print(old, rec_type, note_type, counter)
+    #                     rec_obj = as_ops.get_record(uri)
+    #                     rec_obj = models.filter_note_type(as_ops, csv_data,
+    #                                                       rec_obj, note_type,
+    #                                                       'find_replace_test',
+    #                                                       old, new)
+    #         else:
+    #             print(uri, ' skipped')
     if len(csv_data) != 0:
         models.create_csv(csv_data, 'replace_str')
     else:

--- a/asaps/models.py
+++ b/asaps/models.py
@@ -29,6 +29,25 @@ class AsOperations:
         record = self.client.get(uri).json()
         return Record(record)
 
+    def get_all_records(self, rec_type, repo_id):
+        """Retrieve records of a specified type."""
+        rec_type_dict = {'accession': 'accessions', 'resource': 'resources',
+                         'archival_object': 'archival_objects,',
+                         'agent_corporate_entity': 'corporate_entities',
+                         'agent_person': 'people', 'agent_family': 'families',
+                         'top_container': 'top_containers'}
+        agents = ['corporate_entities', 'families', 'people']
+        non_repo_types = ['locations', 'subjects']
+        if rec_type in agents:
+            endpoint = f'agents/{rec_type}'
+        elif rec_type in non_repo_types:
+            endpoint = rec_type
+        else:
+            endpoint = (f'repositories/{repo_id}/{rec_type_dict[rec_type]}')
+        print(endpoint)
+        ids = self.client.get(f'{endpoint}?all_ids=true').json()
+        return ids, endpoint
+
     def search(self, string, repo_id, rec_type):
         """Search for a string across a particular record type."""
         endpoint = (f'repositories/{repo_id}/search?q="{string}'

--- a/asaps/models.py
+++ b/asaps/models.py
@@ -29,8 +29,8 @@ class AsOperations:
         record = self.client.get(uri).json()
         return Record(record)
 
-    def get_all_records(self, rec_type, repo_id):
-        """Retrieve records of a specified type."""
+    def create_endpoint(self, rec_type, repo_id):
+        """Create an endpoint for a specified type."""
         rec_type_dict = {'accession': 'accessions', 'resource': 'resources',
                          'archival_object': 'archival_objects,',
                          'agent_corporate_entity': 'corporate_entities',
@@ -44,9 +44,12 @@ class AsOperations:
             endpoint = rec_type
         else:
             endpoint = (f'repositories/{repo_id}/{rec_type_dict[rec_type]}')
-        print(endpoint)
+        return endpoint
+
+    def get_all_records(self, endpoint):
+        """Retrieve all records from a specified endpoint."""
         ids = self.client.get(f'{endpoint}?all_ids=true').json()
-        return ids, endpoint
+        return ids
 
     def search(self, string, repo_id, rec_type):
         """Search for a string across a particular record type."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,16 +25,22 @@ def test_get_record(as_ops):
         assert response == json_object
 
 
+def test_create_endpoint(as_ops):
+    """Test create_endpoint function."""
+    rec_type = 'resource'
+    repo_id = '0'
+    endpoint = as_ops.create_endpoint(rec_type, repo_id)
+    assert endpoint == 'repositories/0/resources'
+
+
 def test_get_all_records(as_ops):
     """Test get_all_records function."""
     with requests_mock.Mocker() as m:
-        rec_type = 'resource'
-        repo_id = '0'
+        endpoint = 'repositories/0/resources'
         json_object = [1, 2, 3, 4]
         m.get('/repositories/0/resources?all_ids=true', json=json_object)
-        ids, endpoint = as_ops.get_all_records(rec_type, repo_id)
+        ids = as_ops.get_all_records(endpoint)
         assert ids == [1, 2, 3, 4]
-        assert endpoint == 'repositories/0/resources'
 
 
 def test_record_is_modified():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,6 +25,18 @@ def test_get_record(as_ops):
         assert response == json_object
 
 
+def test_get_all_records(as_ops):
+    """Test get_all_records function."""
+    with requests_mock.Mocker() as m:
+        rec_type = 'resource'
+        repo_id = '0'
+        json_object = [1, 2, 3, 4]
+        m.get('/repositories/0/resources?all_ids=true', json=json_object)
+        ids, endpoint = as_ops.get_all_records(rec_type, repo_id)
+        assert ids == [1, 2, 3, 4]
+        assert endpoint == 'repositories/0/resources'
+
+
 def test_record_is_modified():
     record = models.Record()
     assert not record.modified


### PR DESCRIPTION
#### What does this PR do?
Adding a get_all_records method which handles the fact that some record endpoints are repo-specific (resources, accessions, AOs, etc.) and some are not (agents, locations, subjects). I'm using the ref_type_dict to address the difference between endpoint URLs and how that rec_type needs to be used in the search method and how it appears in the jsonmodel_type property in an AS record. I don't have another use case for it yet but I can move it out of the method if another comes up. I'm also returning the endpoint along with the ids to construct full URIs when subsequently calling the get_record method (see cli.py for typical usage)

#### Includes new or updated dependencies?
NO
