### PR TITLE
digital object update

### DIFF
--- a/asaps/models.py
+++ b/asaps/models.py
@@ -77,6 +77,21 @@ class AsOperations:
                 aolist.append(ao_uri)
         return aolist
 
+    def update_dig_obj_link(self, do, link):
+        """Get digital objects associated with an archival objects."""
+        do['digital_object_id'] = link
+        if len(do['file_versions']) != 0:
+            for file_version in do['file_versions']:
+                file_version['file_uri'] = link
+        else:
+            file_version = {}
+            file_version['file_uri'] = link
+            file_version['publish'] = True
+            file_version['is_representative'] = False
+            file_version['jsonmodel_type'] = 'file_version'
+            do['file_versions'] = [file_version]
+        return do
+
 
 class Record(dict):
     def __init__(self, *args, **kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -28,7 +28,7 @@ def test_get_record(as_ops):
 
 
 def test_create_endpoint(as_ops):
-    """Test create_endpoint function."""
+    """Test create_endpoint method."""
     rec_type = 'resource'
     repo_id = '0'
     endpoint = as_ops.create_endpoint(rec_type, repo_id)
@@ -36,7 +36,7 @@ def test_create_endpoint(as_ops):
 
 
 def test_get_all_records(as_ops):
-    """Test get_all_records function."""
+    """Test get_all_records method."""
     with requests_mock.Mocker() as m:
         endpoint = '/repositories/0/resources'
         json_object = [1, 2, 3, 4]
@@ -110,7 +110,7 @@ def test_save_record_flushes_changes(as_ops):
 
 
 def test_get_aos_for_resource(as_ops):
-    """Test get_aos_for_resource function."""
+    """Test get_aos_for_resource method."""
     with requests_mock.Mocker() as m:
         resource = '/repositories/2/resources/423'
         json_object = {'record_uri': '/archival_objects/1234', 'children':
@@ -118,6 +118,17 @@ def test_get_aos_for_resource(as_ops):
         m.get(f'{resource}/tree', json=json_object)
         aolist = as_ops.get_aos_for_resource(resource)
         assert '/archival_objects/5678' in aolist
+
+
+def test_update_dig_obj_link(as_ops):
+    """Test update_dig_obj_link method."""
+    update = 'TEST'
+    do = {'digital_object_id': 'fish', 'file_versions': [{'file_uri':
+          'fish'}]}
+    do = as_ops.update_dig_obj_link(do, update)
+    assert do['digital_object_id'] == update
+    for file_version in do['file_versions']:
+        assert file_version['file_uri'] == update
 
 
 def test_audit():


### PR DESCRIPTION
#### What does this PR do?
Adds functionality and test for updating digital objects with new URLs from a CSV file with digital object URIs and the corresponding content links. If there is not an existing file_version associated with the digital object, one will be created by this function. This is the final part of the DOS ingest workflow for content that is represented in ArchivesSpace

#### Includes new or updated dependencies?
YES
