### PR TITLE
AO & DO creation workflow

### DIFF
--- a/asaps/cli.py
+++ b/asaps/cli.py
@@ -8,7 +8,7 @@ from asnake.client import ASnakeClient
 import click
 import structlog
 
-from asaps import models
+from asaps import models, records
 
 logger = structlog.get_logger()
 
@@ -75,7 +75,7 @@ def report(ctx, repo_id, rec_type, field):
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
-    endpoint = as_ops.create_endpoint(rec_type, repo_id)
+    endpoint = models.create_endpoint(rec_type, repo_id)
     ids = as_ops.get_all_records(endpoint)
     for id in ids:
         uri = f'{endpoint}/{id}'
@@ -118,12 +118,12 @@ def find(ctx, dry_run, repo_id, rec_type, field, search, rpl_value):
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
-    skipped_aos = []
+    skipped_arch_objs = []
     if rec_type == 'archival_object':
         for uri in skipped_resources:
-            aolist = as_ops.get_aos_for_resource(uri)
-            skipped_aos.append(aolist)
-    skipped_uris = skipped_resources + skipped_aos
+            arch_objlist = as_ops.get_arch_objs_for_resource(uri)
+            skipped_arch_objs.append(arch_objlist)
+    skipped_uris = skipped_resources + skipped_arch_objs
     for uri in as_ops.search(search, repo_id, rec_type, field):
         if uri not in skipped_uris:
             rec_obj = as_ops.get_record(uri)
@@ -166,7 +166,7 @@ def updatedigobj(ctx, dry_run, mapping_csv):
             do_uri = row['do_uri']
             link = row['link']
             dig_obj = as_ops.get_record(do_uri)
-            upd_dig_obj = as_ops.update_dig_obj_link(dig_obj, link)
+            upd_dig_obj = records.update_dig_obj_link(dig_obj, link)
             if upd_dig_obj.modified is True:
                 as_ops.save_record(upd_dig_obj, dry_run)
     models.elapsed_time(start_time, 'Total runtime:')
@@ -179,31 +179,35 @@ def updatedigobj(ctx, dry_run, mapping_csv):
               help='The mapping CSV file to use.')
 @click.option('-i', '--repo_id', prompt='Enter the repository ID',
               help='The ID of the repository to use.')
-def newaos(ctx, mapping_csv, repo_id):
+def newarchobjs(ctx, mapping_csv, repo_id):
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
     with open(mapping_csv) as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            agent_link = as_ops.create_agent_link(row['publisher'], 'creator',
-                                                  'pbl')
-            new_dig_obj = as_ops.create_dig_obj(row['title'], row['link'])
-            note = as_ops.create_note('scopecontent',
-                                      'Scope and Contents of the Collection',
-                                      row['abstract'])
-            arch_obj = as_ops.create_arch_obj(row['title'], 'file',
-                                              [agent_link], [note],
-                                              row['parent_uri'],
-                                              row['resource'])
-            do_endpoint = as_ops.create_endpoint('digital_object', repo_id)
-            do_resp = as_ops.post_new_record(new_dig_obj, do_endpoint)
-            arch_obj = as_ops.link_dig_obj(arch_obj, do_resp['uri'])
-            dig_obj = as_ops.get_record(do_resp['uri'])
-            upd_dig_obj = as_ops.update_dig_obj_link(dig_obj, row['link'])
-            as_ops.save_record(upd_dig_obj, 'False')
-            ao_endpoint = as_ops.create_endpoint('archival_object', repo_id)
-            ao_resp = as_ops.post_new_record(arch_obj, ao_endpoint)
+            new_dig_obj = records.create_dig_obj(row['title'], row['link'])
+            dig_obj_endpoint = models.create_endpoint('digital_object',
+                                                      repo_id)
+            dig_obj_resp = as_ops.post_new_record(new_dig_obj,
+                                                  dig_obj_endpoint)
+            agent_link = {'role': 'creator', 'relator': 'pbl', 'ref':
+                          row['publisher']}
+            note = records.create_note('scopecontent',
+                                       'Scope and Contents of the Collection',
+                                       row['abstract'])
+            arch_obj = records.create_arch_obj(row['title'], 'file',
+                                               [agent_link], [note],
+                                               row['parent_uri'],
+                                               row['resource'])
+            arch_obj = records.link_dig_obj(arch_obj, dig_obj_resp['uri'])
+            arch_obj = records.link_top_container(arch_obj,
+                                                  row['top_container'],
+                                                  row['child_type'],
+                                                  row['child_indicator'])
+            arch_obj_endpoint = models.create_endpoint('archival_object',
+                                                       repo_id)
+            arch_obj_resp = as_ops.post_new_record(arch_obj, arch_obj_endpoint)
     models.elapsed_time(start_time, 'Total runtime:')
     models.create_csv_from_log('dig_obj', log_suffix)
 

--- a/asaps/models.py
+++ b/asaps/models.py
@@ -26,9 +26,10 @@ class AsOperations:
     def create_endpoint(self, rec_type, repo_id):
         """Create an endpoint for a specified type."""
         rec_type_dict = {'accession': 'accessions', 'resource': 'resources',
-                         'archival_object': 'archival_objects,',
+                         'archival_object': 'archival_objects',
                          'agent_corporate_entity': 'corporate_entities',
                          'agent_person': 'people', 'agent_family': 'families',
+                         'digital_object': 'digital_objects',
                          'top_container': 'top_containers'}
         agents = ['corporate_entities', 'families', 'people']
         non_repo_types = ['locations', 'subjects']
@@ -67,6 +68,47 @@ class AsOperations:
             logger.info(response.json())
         rec_obj.flush()
 
+    def post_new_record(self, rec_obj, endpoint):
+        """Create new ArchivesSpace record with POST of JSON data."""
+        response = self.client.post(endpoint, json=rec_obj)
+        response.raise_for_status()
+        logger.info(response.json())
+        return response.json()
+
+    def create_arch_obj(self, title, level, agents, notes, parent, resource):
+        """Create archival object."""
+        arch_obj = {}
+        arch_obj['title'] = title
+        arch_obj['level'] = level
+        arch_obj['linked_agents'] = agents
+        arch_obj['notes'] = notes
+        arch_obj['publish'] = True
+        arch_obj['parent'] = {'ref': parent}
+        arch_obj['resource'] = {'ref': resource}
+        return arch_obj
+
+    def create_dig_obj(self, title, link):
+        """Create digital object."""
+        dig_obj = {}
+        dig_obj['digital_object_id'] = link
+        dig_obj['title'] = title
+        dig_obj['publish'] = True
+        return dig_obj
+
+    def create_note(self, type, label, content):
+        """Create note object."""
+        note = {}
+        note['jsonmodel_type'] = 'note_multipart'
+        note['type'] = type
+        note['label'] = label
+        note['publish'] = True
+        subnote = {}
+        subnote['publish'] = True
+        subnote['content'] = content
+        subnote['jsonmodel_type'] = 'note_text'
+        note['subnotes'] = [subnote]
+        return note
+
     def get_aos_for_resource(self, uri):
         """Get archival objects associated with a resource."""
         logger.info(f'Retrieving AOs for {uri}')
@@ -76,6 +118,24 @@ class AsOperations:
             if 'archival_objects' in ao_uri:
                 aolist.append(ao_uri)
         return aolist
+
+    def create_agent_link(self, agent_uri, role, relator):
+        """Create link to agent URI."""
+        agent_link = {}
+        agent_link['role'] = role
+        agent_link['relator'] = relator
+        agent_link['ref'] = agent_uri
+        return agent_link
+
+    def link_dig_obj(self, arch_obj, dig_obj_uri):
+        """Link digital object to archival object."""
+        instance = {}
+        instance['instance_type'] = 'digital_object'
+        instance['jsonmodel_type'] = 'instance'
+        instance['digital_object'] = {'ref': dig_obj_uri}
+        instance['is_representative'] = True
+        arch_obj['instances'] = [instance]
+        return arch_obj
 
     def update_dig_obj_link(self, do, link):
         """Get digital objects associated with an archival objects."""
@@ -87,7 +147,7 @@ class AsOperations:
             file_version = {}
             file_version['file_uri'] = link
             file_version['publish'] = True
-            file_version['is_representative'] = False
+            file_version['is_representative'] = True
             file_version['jsonmodel_type'] = 'file_version'
             do['file_versions'] = [file_version]
         return do

--- a/asaps/records.py
+++ b/asaps/records.py
@@ -1,0 +1,83 @@
+def create_arch_obj(title, level, agents, notes, parent, resource):
+    """Create archival object."""
+    arch_obj = {}
+    arch_obj['title'] = title
+    arch_obj['level'] = level
+    arch_obj['linked_agents'] = agents
+    arch_obj['notes'] = notes
+    arch_obj['publish'] = True
+    arch_obj['parent'] = {'ref': parent}
+    arch_obj['resource'] = {'ref': resource}
+    arch_obj['instances'] = []
+    return arch_obj
+
+
+def create_dig_obj(title, link):
+    """Create digital object."""
+    dig_obj = {}
+    dig_obj['title'] = title
+    dig_obj['publish'] = True
+    dig_obj['file_versions'] = []
+    dig_obj = update_dig_obj_link(dig_obj, link)
+    return dig_obj
+
+
+def create_note(type, label, content):
+    """Create note object."""
+    note = {}
+    note['jsonmodel_type'] = 'note_multipart'
+    note['type'] = type
+    note['label'] = label
+    note['publish'] = True
+    subnote = {}
+    subnote['publish'] = True
+    subnote['content'] = content
+    subnote['jsonmodel_type'] = 'note_text'
+    note['subnotes'] = [subnote]
+    return note
+
+
+def link_dig_obj(arch_obj, dig_obj_uri):
+    """Link digital object to archival object."""
+    instance = {}
+    instance['instance_type'] = 'digital_object'
+    instance['jsonmodel_type'] = 'instance'
+    instance['digital_object'] = {'ref': dig_obj_uri}
+    instance['is_representative'] = True
+    arch_obj['instances'].append(instance)
+    return arch_obj
+
+
+def link_top_container(arch_obj, top_cont_uri, child_type,
+                       child_indicator):
+    """Link top container to archival object."""
+    instance = {}
+    instance['instance_type'] = 'mixed_materials'
+    instance['jsonmodel_type'] = 'instance'
+    instance['indicator_2'] = child_indicator
+    instance['type_2'] = child_type
+    sub_container = {}
+    sub_container['indicator_2'] = child_indicator
+    sub_container['type_2'] = child_type
+    sub_container['jsonmodel_type'] = 'sub_container'
+    sub_container['top_container'] = {'ref': top_cont_uri}
+    instance['sub_container'] = sub_container
+    instance['is_representative'] = False
+    arch_obj['instances'].append(instance)
+    return arch_obj
+
+
+def update_dig_obj_link(dig_obj, link):
+    """Get digital objects associated with an archival objects."""
+    dig_obj['digital_object_id'] = link
+    if len(dig_obj['file_versions']) != 0:
+        for file_version in dig_obj['file_versions']:
+            file_version['file_uri'] = link
+    else:
+        file_version = {}
+        file_version['file_uri'] = link
+        file_version['publish'] = True
+        file_version['is_representative'] = True
+        file_version['jsonmodel_type'] = 'file_version'
+        dig_obj['file_versions'] = [file_version]
+    return dig_obj

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,3 +95,47 @@ def test_updatedigobj(runner):
                                     '--mapping_csv', 'mapping.csv'
                                     ])
     assert result.exit_code == 0
+
+
+def test_newaos(runner):
+    """Test report command."""
+    with requests_mock.Mocker() as m:
+        with runner.isolated_filesystem():
+            with open('mapping.csv', 'w') as f:
+                writer = csv.writer(f)
+                writer.writerow(['resource'] + ['parent_uri'] + ['title'] +
+                                ['publisher'] + ['link'] + ['abstract'])
+                writer.writerow(['/repositories/0/resources/123'] +
+                                ['/repositories/0/archival_objects/456'] +
+                                ['Test title'] +
+                                ['/agents/corporate_entities/12'] +
+                                ['http://dos.com/123'] +
+                                ['This is an abstract'])
+            json_object1 = {'session': 'abcdefg1234567'}
+            json_object2 = {'status': 'Created', 'uri':
+                            '/repositories/0/digital_objects/789'}
+            json_object3 = {'uri': '/repositories/0/digital_objects/789',
+                            'file_versions': [{'file_uri':
+                                              'old_content_link'}]}
+            json_object4 = {'status': 'Updated'}
+            json_object5 = {'status': 'Created', 'uri':
+                            '/repositories/0/archival_objects/123'}
+            base_url = 'mock://mock.mock/users/test/login'
+            do_url = '/repositories/0/digital_objects'
+            item_url = '/repositories/0/digital_objects/789'
+            ao_url = '/repositories/0/archival_objects'
+            m.post(base_url, json=json_object1)
+            m.post(do_url, json=json_object2)
+            m.get(item_url, json=json_object3)
+            m.post(item_url, json=json_object4)
+            m.post(ao_url, json=json_object5)
+            result = runner.invoke(main,
+                                   ['--url', 'mock://mock.mock',
+                                    '--username', 'test',
+                                    '--password', 'testpass',
+                                    'newaos',
+                                    '--repo_id', '0',
+                                    '--mapping_csv', 'mapping.csv'
+                                    ])
+            print(result.output)
+    assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,20 +97,24 @@ def test_updatedigobj(runner):
     assert result.exit_code == 0
 
 
-def test_newaos(runner):
+def test_newarchobjs(runner):
     """Test report command."""
     with requests_mock.Mocker() as m:
         with runner.isolated_filesystem():
             with open('mapping.csv', 'w') as f:
                 writer = csv.writer(f)
                 writer.writerow(['resource'] + ['parent_uri'] + ['title'] +
-                                ['publisher'] + ['link'] + ['abstract'])
+                                ['publisher'] + ['link'] + ['abstract'] +
+                                ['top_container'] + ['child_type'] +
+                                ['child_indicator'])
                 writer.writerow(['/repositories/0/resources/123'] +
                                 ['/repositories/0/archival_objects/456'] +
                                 ['Test title'] +
                                 ['/agents/corporate_entities/12'] +
                                 ['http://dos.com/123'] +
-                                ['This is an abstract'])
+                                ['This is an abstract'] +
+                                ['/repositories/0/top_containers/123'] +
+                                ['reel'] + ['2'])
             json_object1 = {'session': 'abcdefg1234567'}
             json_object2 = {'status': 'Created', 'uri':
                             '/repositories/0/digital_objects/789'}
@@ -123,17 +127,17 @@ def test_newaos(runner):
             base_url = 'mock://mock.mock/users/test/login'
             do_url = '/repositories/0/digital_objects'
             item_url = '/repositories/0/digital_objects/789'
-            ao_url = '/repositories/0/archival_objects'
+            arch_obj_url = '/repositories/0/archival_objects'
             m.post(base_url, json=json_object1)
             m.post(do_url, json=json_object2)
             m.get(item_url, json=json_object3)
             m.post(item_url, json=json_object4)
-            m.post(ao_url, json=json_object5)
+            m.post(arch_obj_url, json=json_object5)
             result = runner.invoke(main,
                                    ['--url', 'mock://mock.mock',
                                     '--username', 'test',
                                     '--password', 'testpass',
-                                    'newaos',
+                                    'newarchobjs',
                                     '--repo_id', '0',
                                     '--mapping_csv', 'mapping.csv'
                                     ])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,6 +97,73 @@ def test_save_record(as_ops, caplog):
         assert message == json_object
 
 
+def test_post_new_record(as_ops):
+    """Test post_new_record method."""
+    with requests_mock.Mocker() as m:
+        endpoint = '/repositories/0/resources'
+        json_object = {'status': 'Created'}
+        rec_obj = {'title': 'Test title'}
+        m.post(endpoint, json=json_object)
+        resp = as_ops.post_new_record(rec_obj, endpoint)
+        assert resp['status'] == 'Created'
+
+
+def test_create_arch_obj(as_ops):
+    """Test create_arch_obj method."""
+    title = 'Test title'
+    level = 'series'
+    notes = []
+    agents = [{'ref': '/agents/123'}]
+    parent = '/repositories/0/archival_objects/123'
+    resource = '/repositories/0/resources/456'
+    arch_obj = as_ops.create_arch_obj(title, level, agents, notes,
+                                      parent, resource)
+    assert arch_obj['title'] == title
+    assert arch_obj['level'] == level
+    assert arch_obj['linked_agents'] == agents
+    assert arch_obj['parent']['ref'] == parent
+    assert arch_obj['resource']['ref'] == resource
+
+
+def test_create_dig_obj(as_ops):
+    """Test create_dig_obj method."""
+    title = 'Test title'
+    link = '/repositories/0/digital_objects/123'
+    dig_obj = as_ops.create_dig_obj(title, link)
+    assert dig_obj['title'] == title
+    assert dig_obj['digital_object_id'] == link
+
+
+def test_create_note(as_ops):
+    """Test create_note method."""
+    content = 'Test content'
+    label = 'Scope and Content Note'
+    type = 'scopecontent'
+    note = as_ops.create_note(type, label, content)
+    assert note['label'] == label
+    assert note['subnotes'][0]['content'] == content
+    assert note['type'] == type
+
+
+def test_create_agent_link(as_ops):
+    """Test create_agent_link method."""
+    agent_uri = '/agents/123'
+    role = 'pbl'
+    relator = 'creator'
+    agent_link = as_ops.create_agent_link(agent_uri, role, relator)
+    assert agent_link['ref'] == agent_uri
+    assert agent_link['role'] == role
+    assert agent_link['relator'] == relator
+
+
+def test_link_dig_obj(as_ops):
+    """Test link_dig_obj method."""
+    arch_obj = {'instances': []}
+    dig_obj_uri = '/repositories/0/digital_objects/123'
+    arch_obj = as_ops.link_dig_obj(arch_obj, dig_obj_uri)
+    assert arch_obj['instances'][0]['digital_object']['ref'] == dig_obj_uri
+
+
 def test_save_record_flushes_changes(as_ops):
     with requests_mock.Mocker() as m:
         uri = '/foo/bar/1'

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,69 @@
+from asaps import records
+
+
+def test_create_arch_obj():
+    """Test create_arch_obj method."""
+    title = 'Test title'
+    level = 'series'
+    notes = []
+    agents = [{'ref': '/agents/123'}]
+    parent = '/repositories/0/archival_objects/123'
+    resource = '/repositories/0/resources/456'
+    arch_obj = records.create_arch_obj(title, level, agents, notes,
+                                       parent, resource)
+    assert arch_obj['title'] == title
+    assert arch_obj['level'] == level
+    assert arch_obj['linked_agents'] == agents
+    assert arch_obj['parent']['ref'] == parent
+    assert arch_obj['resource']['ref'] == resource
+
+
+def test_create_dig_obj():
+    """Test create_dig_obj method."""
+    title = 'Test title'
+    link = '/repositories/0/digital_objects/123'
+    dig_obj = records.create_dig_obj(title, link)
+    assert dig_obj['title'] == title
+    assert dig_obj['digital_object_id'] == link
+
+
+def test_create_note():
+    """Test create_note method."""
+    content = 'Test content'
+    label = 'Scope and Content Note'
+    type = 'scopecontent'
+    note = records.create_note(type, label, content)
+    assert note['label'] == label
+    assert note['subnotes'][0]['content'] == content
+    assert note['type'] == type
+
+
+def test_link_dig_obj():
+    """Test link_dig_obj method."""
+    arch_obj = {'instances': []}
+    dig_obj_uri = '/repositories/0/digital_objects/123'
+    arch_obj = records.link_dig_obj(arch_obj, dig_obj_uri)
+    assert arch_obj['instances'][0]['digital_object']['ref'] == dig_obj_uri
+
+
+def test_link_top_container():
+    """Test link_top_container method."""
+    arch_obj = {'instances': []}
+    top_cont_uri = '/repositories/0/top_containers/123'
+    child_type = 'barrel'
+    child_indicator = '1'
+    arch_obj = records.link_top_container(arch_obj, top_cont_uri, child_type,
+                                          child_indicator)
+    assert (arch_obj['instances'][0]['sub_container']['top_container']
+            ['ref']) == top_cont_uri
+
+
+def test_update_dig_obj_link():
+    """Test update_dig_obj_link method."""
+    update = 'TEST'
+    do = {'digital_object_id': 'fish', 'file_versions': [{'file_uri':
+          'fish'}]}
+    do = records.update_dig_obj_link(do, update)
+    assert do['digital_object_id'] == update
+    for file_version in do['file_versions']:
+        assert file_version['file_uri'] == update


### PR DESCRIPTION
#### What does this PR do?
The cli command is for a workflow will use a CSV to create archival objects (representing the intellectual content) and digital objects (representing a digital manifestation of that content) and then post these new objects to the ArchivesSpace API.

The following methods were added for this workflow: 
- create a digital object
- create an archival object
- add digital object link to an archival object
- add agent links to any type of record
- add notes to any type of record
- post new records of any type

Corresponding tests for all new methods and cli commands are also included.

#### Includes new or updated dependencies?
NO
