### PR TITLE
workflows module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.7"
+  - "3.8"
 install:
   - pipenv install --dev
 script:

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ jsonpointer = "*"
 structlog = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"
 
 [scripts]
 asaps = "python -c \"from asaps.cli import main; main()\""

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "89ecfeeb286ee572552844669be9549cbdb4148a93ac80d8560e02385aec0c97"
+            "sha256": "036cec7bf19a266462032eae5499bb4b60ea20da62449031a870aa851b43a2c3"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -18,62 +18,65 @@
     "default": {
         "archivessnake": {
             "hashes": [
-                "sha256:148bc00f2445a42fa1c12f06ba83fc7b0fff439fcd91a6f75a78d52409fae91b",
-                "sha256:ef9656d4306cd2d6376c41296a45c046a37afbae34b2afeffed3ef1be4639aca"
+                "sha256:0bdda8e9bc133db3dcea6825c2ecb9211561dcd938648ab67a7c2f0f7264a87e",
+                "sha256:c6c2f15dac48c3556f054454417a584c4f6fcf8d8d7fa0aa4e3892deb45ec50e"
             ],
             "index": "pypi",
-            "version": "==0.8.2"
+            "version": "==0.9.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.3.0"
         },
         "boltons": {
             "hashes": [
-                "sha256:83cff3975ea301144dc985395a7ea847c71d9641334b852595897a92a85e51af",
-                "sha256:e44ddbd10af0904147c194d2c9bd2affa6a3e5b2ebfb9d5547900d8931203953"
+                "sha256:3dd8a8e3c1886e7f7ba3422b50f55a66e1700161bf01b919d098e7d96dd2d9b6",
+                "sha256:dd362291a460cc1e0c2e91cc6a60da3036ced77099b623112e8f833e6734bdc5"
             ],
-            "version": "==20.0.0"
+            "version": "==20.2.1"
         },
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "click": {
             "hashes": [
-                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
-                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
             ],
             "index": "pypi",
-            "version": "==7.0"
+            "version": "==7.1.2"
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
         "jsonpatch": {
             "hashes": [
-                "sha256:83f29a2978c13da29bfdf89da9d65542d62576479caf215df19632d7dc04c6e6",
-                "sha256:cbb72f8bf35260628aea6b508a107245f757d1ec839a19c34349985e2c05645a"
+                "sha256:da3831be60919e8c98564acfc1fa918cb96e7c9750b0428388483f04d0d1c5a7",
+                "sha256:e930adc932e4d36087dbbf0f22e1ded32185dfb20662f2e3dd848677a5295a14"
             ],
             "index": "pypi",
-            "version": "==1.24"
+            "version": "==1.28"
         },
         "jsonpointer": {
             "hashes": [
@@ -85,123 +88,214 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
-                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
+                "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced",
+                "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"
             ],
-            "version": "==8.0.2"
+            "markers": "python_version >= '3.5'",
+            "version": "==8.7.0"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:059b2ee3194d718896c0ad077dd8c043e5e909d9180f387ce42012662a4946d6",
-                "sha256:1cf708e2ac57f3aabc87405f04b86354f66799c8e62c28c5fc5f88b5521b2dbf",
-                "sha256:24521fa2890642614558b492b473bee0ac1f8057a7263156b02e8b14c88ce6f5",
-                "sha256:4fee71aa5bc6ed9d5f116327c04273e25ae31a3020386916905767ec4fc5317e",
-                "sha256:70024e02197337533eef7b85b068212420f950319cc8c580261963aefc75f811",
-                "sha256:74782fbd4d4f87ff04159e986886931456a1894c61229be9eaf4de6f6e44b99e",
-                "sha256:940532b111b1952befd7db542c370887a8611660d2b9becff75d39355303d82d",
-                "sha256:cb1f2f5e426dc9f07a7681419fe39cee823bb74f723f36f70399123f439e9b20",
-                "sha256:dbbb2379c19ed6042e8f11f2a2c66d39cceb8aeace421bfc29d085d93eda3689",
-                "sha256:e3a057b7a64f1222b56e47bcff5e4b94c4f61faac04c7c4ecb1985e18caa3994",
-                "sha256:e9f45bd5b92c7974e59bcd2dcc8631a6b6cc380a904725fce7bc08872e691615"
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"
             ],
-            "version": "==5.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
+        },
+        "rapidfuzz": {
+            "hashes": [
+                "sha256:04c4a27b1bd475d36e9003380220a862163a079184043c27e7443c9aded09c86",
+                "sha256:06edb5a49b487499857b575028182c3f75361c6c22950661c598d36cc584af3c",
+                "sha256:0d08a0bb5a6cd164d899a8f17fece7f5e54e040ccbe17dd38d56603b1ee3319a",
+                "sha256:0dbd7d197d1a590c2671cbc7f67ba6979548deb1827c45963bc48deddc509207",
+                "sha256:15c9ac1279ce9103dfe377b1a51f0548f6cc08c7d58d6bc45e9f224e5ab310d0",
+                "sha256:164ad3790d361d5264972c4cfec97f1ff3ea9a7b451208e84ca873f4a88bda06",
+                "sha256:1d858ec78a99ea8e32d86925166434788522f5020ade02648c85bb3fc3f4f6de",
+                "sha256:2b657bb9cc69d5729d1f0799f13ca9632fccba1a588bef78012bdd51f07b7ee8",
+                "sha256:31bb95bc8c3425f81f161f07b00a50c67a1d16eac3f4fb5e3bd0fdcdd8b9334f",
+                "sha256:3724934e8037befd18901bf7f26cc9e041c3cdfae222e54fe6e6afd6e4cb0e26",
+                "sha256:3a1039ca6136d957aa30b9743f3f627ef0662a26e8d5f722815866d1cdfb396b",
+                "sha256:3e6f6c9757823aab42d6216800eb942f31d100a22a07ec666058ccb224ede5ab",
+                "sha256:3f885029755fcaea0449d3bb7cbbc551b24e1e9441fdc273472d81c02f30ae7f",
+                "sha256:41dc6326d445d8e7afff53f1194ea3a2a7342d578efdc29748fb33eb479c97f6",
+                "sha256:4947c60f073d0970ba8ca7456dd94e610672d79886689363f6175fc9d68cceee",
+                "sha256:4cd9aa9e10b3f47bd64bbdac5a13168725dffbfcf24f1b79d602c1a139823e1e",
+                "sha256:52512ba8940c9fac1eb9c18771ca0cf20ec9d61b48960b8e0f149ae64e73042e",
+                "sha256:5ad59cfc2c9f6a214c814de8b9e94309f82943a902f7acea307d9d5be2b0cccb",
+                "sha256:611751f2164bc2a14f008b6ac45a7d0fd14d145934ddd9a6ece786560deb0148",
+                "sha256:6a6447d9612cc7ba0dfc93e5d4a92a1d8022bf4f693fe36dfd4a79326e91c151",
+                "sha256:74196c59e16a141e61161bd902f7cddab73571ee89951f1fd6acba6a7cc8a131",
+                "sha256:753924c78fd6d754e4640832eebf662e8696ac9c1be9bddf2a530e5d72f6d065",
+                "sha256:79bdac4250d1dd33ec7abaa4b5a047d96f21a3f8c5f736f47371ad17c2fa10ac",
+                "sha256:822adafbc76c2cf2f0966fd9c20683d46b6cf5a09b6020526fb1ab0cc6b3db73",
+                "sha256:8548e2a9462cccfd26529eed6f9a891f48e55c800c08cb8ed2c8c612dcc5ff09",
+                "sha256:85ed82af38aaed64e34adcbdeb629d2e514f306ca8539e92906028a792228113",
+                "sha256:86056bf87b177e3a4e899bf50ee21da0ac72c27a9e6c5b75b816fa775c3199fe",
+                "sha256:8789b6105168796d7478304a8886e2d735fe63ff60f3641da6d3dedb292fda9d",
+                "sha256:8921f620a995cba93d3cf97a4386abd7633ee78bdbb5cfda4c5a08057edcffad",
+                "sha256:8c08b696e1d7edc897bd15df549c312276403741271a3e7d779653b757c3bc85",
+                "sha256:8ecd71bb161953daf7524f095d9484791c984bfc93b8f9ea06b16ef4143dee4a",
+                "sha256:90d6b1c78fb9b51efe5a9a042977339435c8c007e36c8d81ddc21098ff5b9fc2",
+                "sha256:932bf1316d15e5cc79f32406d8c96a06749494df4b7c1fdc620b482370a38958",
+                "sha256:94f73da4a5c783b1743530fd1c85e2311e749f9f7e557360f1d2a87d6a444f94",
+                "sha256:9e3a0daea2bcfda554897586afde99807bacb44672613a4c52f9a87388627e70",
+                "sha256:a6633fe5ed0361f4145d01ae8fde8564609f178614bb3341d96a71a9c0b051b0",
+                "sha256:a6cf3263dec303acc034b74b4060492fea898f05855947b024e9aade5ecc264e",
+                "sha256:a795b393dc537aafbfbbc936eec0a6189ae7dc42afe459a62b0be41e30fbd5d8",
+                "sha256:b01988ceb5fa891828485d3861d629716b6fe28d7d632e643c0fd8a847612c54",
+                "sha256:b491e68620a31d5059ae83a7d6955142d3b68b6852b0da8dacf1f05742ec848f",
+                "sha256:bbb9a6802231851b6e582c5a7e633e17a333ef3ba5d2da626f43d75c9ce1a96c",
+                "sha256:bd423368637bd6b56e4e89356ad52bb4501100ba2d5e49ccf08c1f476068e234",
+                "sha256:c0309d9c19b0ff7f7420022323237a04f717d9ac6867d90ff9daaa55cf6d8535",
+                "sha256:c58e5d2a94c09220d03fcac7cf5e5c98ffc76ab0343d12238ae8a140cbccdc7a",
+                "sha256:c9c1cde7a546e55d1530ec06840af3781ee3d05e7e21fe0f68203869c2a8bef4",
+                "sha256:d708287eb74f6b432e27ddd0b08a83f76b7b64d818e5066483833067048b06cf",
+                "sha256:d79ace11b1b81f87e6c303ce06b2c0b841938df9694ef6873b94b085cb43827e",
+                "sha256:e028da2c1f2032700412f1812509356d19eb776da67921f8564a9863ae870029",
+                "sha256:e0b316d949f04dfc1953cec35e9caed5cb54d6deb421d6634336c1f000e8d141",
+                "sha256:e43d057b5277bdcf2519c30ca9eb8aa52e047f3e92dcbc45c4600a5f760c148e",
+                "sha256:e6fb951b8d9bde314f024a27b36494fc04a97d7393ab0777e74f9526a7f28da4",
+                "sha256:f19aab9a50e5380c5092d3ebfdb3d1d8a778dadde2ceb32ef9c8bfdbda6f0f72",
+                "sha256:f1f10d7118890f14be78e6b01fca1903e6c621c5f7f9c4ad9224440f96f2e8bd",
+                "sha256:f4f46633dfdac0a25fe53893f8f42213fa22636f70f1c77912d190cd5b9b5fa0",
+                "sha256:f50359da4303c903269e88c00db8ad6cd6f62480cdba2aae3697519a70dcbbec",
+                "sha256:f7821472adb6e416479a7e1d6ed1dbe69627fc0fc648903a7b58fe84cb8b177f",
+                "sha256:fa1ace30c431073218d7717fa747c2298dbbf269faf42cae1471ec49b62c62f5",
+                "sha256:fadbf1ccfdcbba169db24704325421f8389a954cc717512bfa33f2cd3ffc67f7"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==1.1.1"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "version": "==2.22.0"
-        },
-        "six": {
-            "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
-            ],
-            "version": "==1.13.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
         },
         "structlog": {
             "hashes": [
-                "sha256:4287058cf4ce1a59bc5dea290d6386d37f29a37529c9a51cdf7387e51710152b",
-                "sha256:6640e6690fc31d5949bc614c1a630464d3aaa625284aeb7c6e486c3010d73e12"
+                "sha256:62f06fc0ee32fb8580f0715eea66cb87271eb7efb0eaf9af6b639cba8981de47",
+                "sha256:d9d2d890532e8db83c6977a2a676fb1889922ff0c26ad4dc0ecac26f9fafbc57"
             ],
             "index": "pypi",
-            "version": "==19.2.0"
+            "version": "==21.1.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
+                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
             ],
-            "version": "==1.25.7"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.3"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
+                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.3.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
-                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
             ],
-            "version": "==2019.11.28"
+            "version": "==2020.12.5"
         },
         "chardet": {
             "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
-            "version": "==3.0.4"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
         },
         "coverage": {
             "hashes": [
-                "sha256:189aac76d6e0d7af15572c51892e7326ee451c076c5a50a9d266406cd6c49708",
-                "sha256:1bf7ba2af1d373a1750888724f84cffdfc697738f29a353c98195f98fc011509",
-                "sha256:1f4ee8e2e4243971618bc16fcc4478317405205f135e95226c2496e2a3b8dbbf",
-                "sha256:225e79a5d485bc1642cb7ba02281419c633c216cdc6b26c26494ba959f09e69f",
-                "sha256:23688ff75adfa8bfa2a67254d889f9bdf9302c27241d746e17547c42c732d3f4",
-                "sha256:28f7f73b34a05e23758e860a89a7f649b85c6749e252eff60ebb05532d180e86",
-                "sha256:2d0cb9b1fe6ad0d915d45ad3d87f03a38e979093a98597e755930db1f897afae",
-                "sha256:47874b4711c5aeb295c31b228a758ce3d096be83dc37bd56da48ed99efb8813b",
-                "sha256:511ec0c00840e12fb4e852e4db58fa6a01ca4da72f36a9766fae344c3d502033",
-                "sha256:53e7438fef0c97bc248f88ba1edd10268cd94d5609970aaf87abbe493691af87",
-                "sha256:569f9ee3025682afda6e9b0f5bb14897c0db03f1a1dc088b083dd36e743f92bb",
-                "sha256:593853aa1ac6dcc6405324d877544c596c9d948ef20d2e9512a0f5d2d3202356",
-                "sha256:5b0a07158360d22492f9abd02a0f2ee7981b33f0646bf796598b7673f6bbab14",
-                "sha256:7ca3db38a61f3655a2613ee2c190d63639215a7a736d3c64cc7bbdb002ce6310",
-                "sha256:7d1cc7acc9ce55179616cf72154f9e648136ea55987edf84addbcd9886ffeba2",
-                "sha256:88b51153657612aea68fa684a5b88037597925260392b7bb4509d4f9b0bdd889",
-                "sha256:955ec084f549128fa2702f0b2dc696392001d986b71acd8fd47424f28289a9c3",
-                "sha256:b251c7092cbb6d789d62dc9c9e7c4fb448c9138b51285c36aeb72462cad3600e",
-                "sha256:bd82b684bb498c60ef47bb1541a50e6d006dde8579934dcbdbc61d67d1ea70d9",
-                "sha256:bfe102659e2ec13b86c7f3b1db6c9a4e7beea4255058d006351339e6b342d5d2",
-                "sha256:c1e4e39e43057396a5e9d069bfbb6ffeee892e40c5d2effbd8cd71f34ee66c4d",
-                "sha256:cb2b74c123f65e8166f7e1265829a6c8ed755c3cd16d7f50e75a83456a5f3fd7",
-                "sha256:cca38ded59105f7705ef6ffe1e960b8db6c7d8279c1e71654a4775ab4454ca15",
-                "sha256:cf908840896f7aa62d0ec693beb53264b154f972eb8226fb864ac38975590c4f",
-                "sha256:d095a7b473f8a95f7efe821f92058c8a2ecfb18f8db6677ae3819e15dc11aaae",
-                "sha256:d22b4297e7e4225ccf01f1aa55e7a96412ea0796b532dd614c3fcbafa341128e",
-                "sha256:d4a2b578a7a70e0c71f662705262f87a456f1e6c1e40ada7ea699abaf070a76d",
-                "sha256:ddeb42a3d5419434742bf4cc71c9eaa22df3b76808e23a82bd0b0bd360f1a9f1",
-                "sha256:e65a5aa1670db6263f19fdc03daee1d7dbbadb5cb67fd0a1f16033659db13c1d",
-                "sha256:eaad65bd20955131bcdb3967a4dea66b4e4d4ca488efed7c00d91ee0173387e8",
-                "sha256:f45fba420b94165c17896861bb0e8b27fb7abdcedfeb154895d8553df90b7b00"
+                "sha256:03ed2a641e412e42cc35c244508cf186015c217f0e4d496bf6d7078ebe837ae7",
+                "sha256:04b14e45d6a8e159c9767ae57ecb34563ad93440fc1b26516a89ceb5b33c1ad5",
+                "sha256:0cdde51bfcf6b6bd862ee9be324521ec619b20590787d1655d005c3fb175005f",
+                "sha256:0f48fc7dc82ee14aeaedb986e175a429d24129b7eada1b7e94a864e4f0644dde",
+                "sha256:107d327071061fd4f4a2587d14c389a27e4e5c93c7cba5f1f59987181903902f",
+                "sha256:1375bb8b88cb050a2d4e0da901001347a44302aeadb8ceb4b6e5aa373b8ea68f",
+                "sha256:14a9f1887591684fb59fdba8feef7123a0da2424b0652e1b58dd5b9a7bb1188c",
+                "sha256:16baa799ec09cc0dcb43a10680573269d407c159325972dd7114ee7649e56c66",
+                "sha256:1b811662ecf72eb2d08872731636aee6559cae21862c36f74703be727b45df90",
+                "sha256:1ccae21a076d3d5f471700f6d30eb486da1626c380b23c70ae32ab823e453337",
+                "sha256:2f2cf7a42d4b7654c9a67b9d091ec24374f7c58794858bff632a2039cb15984d",
+                "sha256:322549b880b2d746a7672bf6ff9ed3f895e9c9f108b714e7360292aa5c5d7cf4",
+                "sha256:32ab83016c24c5cf3db2943286b85b0a172dae08c58d0f53875235219b676409",
+                "sha256:3fe50f1cac369b02d34ad904dfe0771acc483f82a1b54c5e93632916ba847b37",
+                "sha256:4a780807e80479f281d47ee4af2eb2df3e4ccf4723484f77da0bb49d027e40a1",
+                "sha256:4a8eb7785bd23565b542b01fb39115a975fefb4a82f23d407503eee2c0106247",
+                "sha256:5bee3970617b3d74759b2d2df2f6a327d372f9732f9ccbf03fa591b5f7581e39",
+                "sha256:60a3307a84ec60578accd35d7f0c71a3a971430ed7eca6567399d2b50ef37b8c",
+                "sha256:6625e52b6f346a283c3d563d1fd8bae8956daafc64bb5bbd2b8f8a07608e3994",
+                "sha256:66a5aae8233d766a877c5ef293ec5ab9520929c2578fd2069308a98b7374ea8c",
+                "sha256:68fb816a5dd901c6aff352ce49e2a0ffadacdf9b6fae282a69e7a16a02dad5fb",
+                "sha256:6b588b5cf51dc0fd1c9e19f622457cc74b7d26fe295432e434525f1c0fae02bc",
+                "sha256:6c4d7165a4e8f41eca6b990c12ee7f44fef3932fac48ca32cecb3a1b2223c21f",
+                "sha256:6d2e262e5e8da6fa56e774fb8e2643417351427604c2b177f8e8c5f75fc928ca",
+                "sha256:6d9c88b787638a451f41f97446a1c9fd416e669b4d9717ae4615bd29de1ac135",
+                "sha256:755c56beeacac6a24c8e1074f89f34f4373abce8b662470d3aa719ae304931f3",
+                "sha256:7e40d3f8eb472c1509b12ac2a7e24158ec352fc8567b77ab02c0db053927e339",
+                "sha256:812eaf4939ef2284d29653bcfee9665f11f013724f07258928f849a2306ea9f9",
+                "sha256:84df004223fd0550d0ea7a37882e5c889f3c6d45535c639ce9802293b39cd5c9",
+                "sha256:859f0add98707b182b4867359e12bde806b82483fb12a9ae868a77880fc3b7af",
+                "sha256:87c4b38288f71acd2106f5d94f575bc2136ea2887fdb5dfe18003c881fa6b370",
+                "sha256:89fc12c6371bf963809abc46cced4a01ca4f99cba17be5e7d416ed7ef1245d19",
+                "sha256:9564ac7eb1652c3701ac691ca72934dd3009997c81266807aef924012df2f4b3",
+                "sha256:9754a5c265f991317de2bac0c70a746efc2b695cf4d49f5d2cddeac36544fb44",
+                "sha256:a565f48c4aae72d1d3d3f8e8fb7218f5609c964e9c6f68604608e5958b9c60c3",
+                "sha256:a636160680c6e526b84f85d304e2f0bb4e94f8284dd765a1911de9a40450b10a",
+                "sha256:a839e25f07e428a87d17d857d9935dd743130e77ff46524abb992b962eb2076c",
+                "sha256:b62046592b44263fa7570f1117d372ae3f310222af1fc1407416f037fb3af21b",
+                "sha256:b7f7421841f8db443855d2854e25914a79a1ff48ae92f70d0a5c2f8907ab98c9",
+                "sha256:ba7ca81b6d60a9f7a0b4b4e175dcc38e8fef4992673d9d6e6879fd6de00dd9b8",
+                "sha256:bb32ca14b4d04e172c541c69eec5f385f9a075b38fb22d765d8b0ce3af3a0c22",
+                "sha256:c0ff1c1b4d13e2240821ef23c1efb1f009207cb3f56e16986f713c2b0e7cd37f",
+                "sha256:c669b440ce46ae3abe9b2d44a913b5fd86bb19eb14a8701e88e3918902ecd345",
+                "sha256:c67734cff78383a1f23ceba3b3239c7deefc62ac2b05fa6a47bcd565771e5880",
+                "sha256:c6809ebcbf6c1049002b9ac09c127ae43929042ec1f1dbd8bb1615f7cd9f70a0",
+                "sha256:cd601187476c6bed26a0398353212684c427e10a903aeafa6da40c63309d438b",
+                "sha256:ebfa374067af240d079ef97b8064478f3bf71038b78b017eb6ec93ede1b6bcec",
+                "sha256:fbb17c0d0822684b7d6c09915677a32319f16ff1115df5ec05bdcaaee40b35f3",
+                "sha256:fff1f3a586246110f34dc762098b5afd2de88de507559e63553d7da643053786"
             ],
             "index": "pypi",
-            "version": "==5.0.2"
+            "version": "==5.4"
         },
         "coveralls": {
             "hashes": [
-                "sha256:2da39aeaef986757653f0a442ba2bef22a8ec602c8bacbc69d39f468dfae12ec",
-                "sha256:906e07a12b2ac04b8ad782d06173975fe5ff815fe9df3bfedd2c099bc5791aec"
+                "sha256:5399c0565ab822a70a477f7031f6c88a9dd196b3de2877b3facb43b51bd13434",
+                "sha256:f8384968c57dee4b7133ae701ecdad88e85e30597d496dcba0d7fbb470dca41f"
             ],
             "index": "pypi",
-            "version": "==1.10.0"
+            "version": "==3.0.0"
         },
         "docopt": {
             "hashes": [
@@ -211,112 +305,106 @@
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
-            "version": "==2.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
         },
-        "importlib-metadata": {
+        "iniconfig": {
             "hashes": [
-                "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45",
-                "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
             ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.3.0"
-        },
-        "more-itertools": {
-            "hashes": [
-                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
-                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
-            ],
-            "version": "==8.0.2"
+            "version": "==1.1.1"
         },
         "packaging": {
             "hashes": [
-                "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb",
-                "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
-            "version": "==20.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
         },
         "pluggy": {
             "hashes": [
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
             "hashes": [
-                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
-                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
-            "version": "==1.8.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
-                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "version": "==2.4.6"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa",
-                "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"
+                "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9",
+                "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"
             ],
             "index": "pypi",
-            "version": "==5.3.2"
+            "version": "==6.2.2"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b",
-                "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"
+                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
+                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
             ],
             "index": "pypi",
-            "version": "==2.8.1"
+            "version": "==2.11.1"
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
-            "version": "==2.22.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.25.1"
         },
         "requests-mock": {
             "hashes": [
-                "sha256:510df890afe08d36eca5bb16b4aa6308a6f85e3159ad3013bac8b9de7bd5a010",
-                "sha256:88d3402dd8b3c69a9e4f9d3a73ad11b15920c6efd36bc27bf1f701cf4a8e4646"
+                "sha256:11215c6f4df72702aa357f205cf1e537cffd7392b3e787b58239bde5fb3db53b",
+                "sha256:e68f46844e4cee9d447150343c9ae875f99fa8037c6dcf5f15bf1fe9ab43d226"
             ],
             "index": "pypi",
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "six": {
             "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "version": "==1.13.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
+                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
             ],
-            "version": "==1.25.7"
-        },
-        "wcwidth": {
-            "hashes": [
-                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
-                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
-            ],
-            "version": "==0.1.8"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
-                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
-            ],
-            "version": "==0.6.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.3"
         }
     }
 }

--- a/asaps/cli.py
+++ b/asaps/cli.py
@@ -73,6 +73,8 @@ def main(ctx, url, username, password):
 @click.option('-f', '--field', prompt='Enter the field',
               help='The field to edit.')
 def deletefield(ctx, dry_run, metadata_csv, field):
+    """Deletes the specified field from records that are specified in a CSV
+     file."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
@@ -107,6 +109,8 @@ def deletefield(ctx, dry_run, metadata_csv, field):
 @click.option('-r', '--rpl_value', prompt='Enter the replacement value',
               help='The replacement value to be inserted.')
 def find(ctx, dry_run, repo_id, rec_type, field, search, rpl_value):
+    """Finds and replaces the specified string in the specified field in all
+     records of the specified type of records"""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
@@ -144,21 +148,24 @@ def find(ctx, dry_run, repo_id, rec_type, field, search, rpl_value):
 
 @main.command()
 @click.pass_context
-@click.option('-r', '--resource', prompt='Enter the resource')
-@click.option('-i', '--field', prompt='Enter the field for file matching',
+@click.option('-r', '--resource', prompt='Enter the resource number')
+@click.option('-i', '--file_identifier',
+              prompt='Enter the field for file matching',
               help='The field for file matching.')
 @click.option('-e', '--repo_id', prompt='Enter the repository ID',
               help='The ID of the repository to use.')
-def metadata(ctx, resource, field, repo_id):
+def metadata(ctx, resource, file_identifier, repo_id):
+    """Exports metadata from a resource's archival objects that will be matched
+     to files in prepartion for ingesting the files into a repository."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
-    resource_num = resource.replace(f'/repositories/{repo_id}/resources/', '')
-    report_dicts = workflows.export_metadata(as_ops, resource, field, repo_id)
+    report_dicts = workflows.export_metadata(as_ops, resource,
+                                             file_identifier, repo_id)
     for report_dict in report_dicts:
         logger.info(**report_dict)
     models.elapsed_time(start_time, 'Total runtime:')
-    models.create_csv_from_log(resource_num, log_suffix, False)
+    models.create_csv_from_log(resource, log_suffix, False)
 
 
 @main.command()
@@ -168,6 +175,7 @@ def metadata(ctx, resource, field, repo_id):
 @click.option('-p', '--match_point', prompt='Enter the match point',
               help='The match point to be used in the new record report.')
 def newagents(ctx, metadata_csv, match_point):
+    """Creates new agent records based on a CSV file."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
@@ -219,6 +227,7 @@ def newagents(ctx, metadata_csv, match_point):
 @click.option('-i', '--repo_id', prompt='Enter the repository ID',
               help='The ID of the repository to use.')
 def newarchobjs(ctx, metadata_csv, agent_file, repo_id):
+    """Creates new archival object records based on a CSV file."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
@@ -261,7 +270,7 @@ def newarchobjs(ctx, metadata_csv, agent_file, repo_id):
                                                   '')
             arch_obj_endpoint = models.create_endpoint('archival_object',
                                                        repo_id)
-            arch_obj_resp = as_ops.post_new_record(arch_obj, arch_obj_endpoint)
+            as_ops.post_new_record(arch_obj, arch_obj_endpoint)
     models.elapsed_time(start_time, 'Total runtime:')
     models.create_csv_from_log('arch_obj', log_suffix)
 
@@ -273,6 +282,7 @@ def newarchobjs(ctx, metadata_csv, agent_file, repo_id):
 @click.option('-i', '--repo_id', prompt='Enter the repository ID',
               help='The ID of the repository to use.')
 def newdigobjs(ctx, metadata_csv, repo_id):
+    """Creates new digital object records based on a CSV file."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
@@ -290,6 +300,8 @@ def newdigobjs(ctx, metadata_csv, repo_id):
               help='The field to extract.')
 @click.pass_context
 def report(ctx, repo_id, rec_type, field):
+    """Exports a report containing minimal metadata and a specified field from
+     all records of the specified type."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
@@ -326,6 +338,7 @@ def report(ctx, repo_id, rec_type, field):
 @click.option('-m', '--metadata_csv', prompt='Enter the metadata CSV file',
               help='The metadata CSV file to use.')
 def updatedigobj(ctx, dry_run, metadata_csv):
+    """Updates the link in digital objects listed in a CSV file."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']
@@ -354,6 +367,7 @@ def updatedigobj(ctx, dry_run, metadata_csv):
               prompt='Enter the replacement value column',
               help='The replacement value to be inserted.')
 def updaterecords(ctx, dry_run, metadata_csv, field, rpl_value_col):
+    """Updates records with values listed in a CSV file."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
     log_suffix = ctx.obj['log_suffix']

--- a/asaps/models.py
+++ b/asaps/models.py
@@ -115,7 +115,7 @@ def concat_id(rec_obj):
     return '-'.join(filter(None, ids))
 
 
-def create_csv_from_log(log_file_name, log_suffix):
+def create_csv_from_log(csv_file_name, log_suffix, include_suffix=True):
     """Create csv from log file."""
     with open(f'logs/log-{log_suffix}') as f:
         logs = f.read().splitlines()
@@ -127,7 +127,10 @@ def create_csv_from_log(log_file_name, log_suffix):
                 line_dict.pop('level')
                 line_dict.pop('timestamp')
                 edit_log_lines.append(line_dict)
-    full_file_name = os.path.abspath(f'{log_file_name}{log_suffix}.csv')
+    if include_suffix:
+        full_file_name = os.path.abspath(f'{csv_file_name}{log_suffix}.csv')
+    else:
+        full_file_name = os.path.abspath(f'{csv_file_name}.csv')
     if len(edit_log_lines) > 0:
         with open(f'{full_file_name}', 'w') as fp:
             header = list(edit_log_lines[0].keys())
@@ -217,6 +220,7 @@ def find_key(nest_dict, key):
 
 
 def string_to_uri(agent_links, string, uri_dict, role, relator=''):
+    """Creates an agent link from a dict of URIs and labels."""
     uri_found = False
     for label, uri in uri_dict.items():
         if string == label:

--- a/asaps/workflows.py
+++ b/asaps/workflows.py
@@ -1,0 +1,31 @@
+import csv
+
+from asaps import models, records
+
+
+def export_metadata(client, resource, field, repo_id):
+    """Export ArchivesSpace metadata as a CSV."""
+    arch_obj_list = client.get_arch_objs_for_resource(resource)
+    for uri in arch_obj_list:
+        rec_obj = client.get_record(uri)
+        report_dict = {'uri': rec_obj['uri'],
+                       'title': rec_obj['display_string'],
+                       'file_identifier': rec_obj.get(field)}
+        yield report_dict
+
+
+def create_new_dig_objs(client, metadata_csv, repo_id):
+    """Creates new digital objects based on a CSV."""
+    with open(metadata_csv) as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            uri = row['uri']
+            arch_obj = client.get_record(uri)
+            new_dig_obj = records.create_dig_obj(arch_obj['display_string'],
+                                                 row['link'])
+            dig_obj_endpoint = models.create_endpoint('digital_object',
+                                                      repo_id)
+            dig_obj_resp = client.post_new_record(new_dig_obj,
+                                                  dig_obj_endpoint)
+            arch_obj = records.link_dig_obj(arch_obj, dig_obj_resp['uri'])
+            client.save_record(arch_obj, 'False')

--- a/asaps/workflows.py
+++ b/asaps/workflows.py
@@ -3,14 +3,15 @@ import csv
 from asaps import models, records
 
 
-def export_metadata(client, resource, field, repo_id):
-    """Export ArchivesSpace metadata as a CSV."""
-    arch_obj_list = client.get_arch_objs_for_resource(resource)
+def export_metadata(client, resource, file_identifier, repo_id):
+    """Export ArchivesSpace metadata as dicts for each archival object."""
+    resource_uri = f'/repositories/{repo_id}/resources/{resource}'
+    arch_obj_list = client.get_arch_objs_for_resource(resource_uri)
     for uri in arch_obj_list:
         rec_obj = client.get_record(uri)
         report_dict = {'uri': rec_obj['uri'],
                        'title': rec_obj['display_string'],
-                       'file_identifier': rec_obj.get(field)}
+                       'file_identifier': rec_obj.get(file_identifier)}
         yield report_dict
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
             'asaps=asaps.cli:main',
         ]
     },
-    python_requires='>=3.7.1',
+    python_requires='>=3.8',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='ArchivesSpace API Python Scripts',
+    name='asaps',
     version='1.0.0',
     description='',
     packages=find_packages(exclude=['tests']),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,16 +19,16 @@ def test_deletefield(runner):
                 writer = csv.writer(f)
                 writer.writerow(['uri'])
                 writer.writerow(['/repositories/0/archival_objects/1234'])
-                json_object1 = {'session': 'abcdefg1234567'}
-                json_object2 = {'uri': '/repositories/0/archival_objects/1234',
-                                'notes': [{'subnotes': [{'content':
-                                                        'Old note content'}]}]}
-                json_object3 = {'status': 'Updated'}
+                session_json = {'session': 'abcdefg1234567'}
+                ao_json = {'uri': '/repositories/0/archival_objects/1234',
+                           'notes': [{'subnotes': [{'content':
+                                                   'Old note content'}]}]}
+                ao_upd_json = {'status': 'Updated'}
                 base_url = 'mock://mock.mock/users/test/login'
                 item_url = '/repositories/0/archival_objects/1234'
-                m.post(base_url, json=json_object1)
-                m.get(item_url, json=json_object2)
-                m.post(item_url, json=json_object3)
+                m.post(base_url, json=session_json)
+                m.get(item_url, json=ao_json)
+                m.post(item_url, json=ao_upd_json)
                 result = runner.invoke(main,
                                        ['--url', 'mock://mock.mock',
                                         '--username', 'test',
@@ -44,18 +44,18 @@ def test_deletefield(runner):
 def test_find(runner):
     """Test find command."""
     with requests_mock.Mocker() as m:
-        json_object1 = {'session': 'abcdefg1234567'}
-        json_object2 = {'uri': '/repositories/0/resources/1234', 'notes':
-                        [{'type': 'acqinfo', 'subnotes': [{'content':
-                         'test value'}]}]}
-        json_object3 = {'status': 'Updated'}
+        session_json = {'session': 'abcdefg1234567'}
+        ao_json = {'uri': '/repositories/0/resources/1234', 'notes':
+                   [{'type': 'acqinfo', 'subnotes': [{'content':
+                    'test value'}]}]}
+        ao_upd_json = {'status': 'Updated'}
         base_url = 'mock://mock.mock/users/test/login'
         search_url = '/repositories/0/search?'
         item_url = '/repositories/0/resources/1234'
-        m.post(base_url, json=json_object1)
-        m.get(search_url, json=[json_object2])
-        m.get(item_url, json=json_object2)
-        m.post(item_url, json=json_object3)
+        m.post(base_url, json=session_json)
+        m.get(search_url, json=[ao_json])
+        m.get(item_url, json=ao_json)
+        m.post(item_url, json=ao_upd_json)
         result = runner.invoke(main,
                                ['--url', 'mock://mock.mock',
                                 '--username', 'test',
@@ -74,21 +74,20 @@ def test_find(runner):
 def test_metadata(runner):
     """Test metadata command"""
     with requests_mock.Mocker() as m:
-        json_object1 = {'session': 'abcdefg1234567'}
-        json_object2 = {'uri': '/repositories/0/resources/1234', 'ref_id':
-                        'a1b_2c3'}
+        session_json = {'session': 'abcdefg1234567'}
+        res_json = {'uri': '/repositories/0/resources/1234', 'ref_id':
+                    'a1b_2c3'}
         base_url = 'mock://mock.mock/users/test/login'
         item_url = '/repositories/0/resources/1234/tree'
-        m.post(base_url, json=json_object1)
-        m.get(item_url, json=json_object2)
+        m.post(base_url, json=session_json)
+        m.get(item_url, json=res_json)
         result = runner.invoke(main,
                                ['--url', 'mock://mock.mock',
                                 '--username', 'test',
                                 '--password', 'testpass',
                                 'metadata',
-                                '--resource',
-                                '/repositories/0/resources/1234',
-                                '--field', 'ref_id', '--repo_id', '0'
+                                '--resource', '1234',
+                                '--file_identifier', 'ref_id', '--repo_id', '0'
                                 ])
         assert result.exit_code == 0
 
@@ -110,13 +109,13 @@ def test_newagents(runner):
                                 + ['mock://mock.mock/123'] + ['John']
                                 + [''] + [''] + [''] + [''] + ['1902-2049']
                                 + ['1902'] + ['2049'] + [''] + ['existence'])
-            json_object1 = {'session': 'abcdefg1234567'}
-            json_object2 = {'status': 'Created', 'uri':
+            session_json = {'session': 'abcdefg1234567'}
+            ag_crtd_json = {'status': 'Created', 'uri':
                             '/agents/people/789'}
             base_url = 'mock://mock.mock/users/test/login'
             agent_url = '/agents/people'
-            m.post(base_url, json=json_object1)
-            m.post(agent_url, json=json_object2)
+            m.post(base_url, json=session_json)
+            m.post(agent_url, json=ag_crtd_json)
             result = runner.invoke(main,
                                    ['--url', 'mock://mock.mock',
                                     '--username', 'test',
@@ -153,24 +152,24 @@ def test_newarchobjs(runner):
                                      + ['/repositories/0/top_containers/456']
                                      + ['reel'] + ['2'] + ['["Smith, J."]']
                                      + [''] + [''] + [''] + [''] + [''])
-                json_object1 = {'session': 'abcdefg1234567'}
-                json_object2 = {'status': 'Created', 'uri':
+                session_json = {'session': 'abcdefg1234567'}
+                do_crtd_json = {'status': 'Created', 'uri':
                                 '/repositories/0/digital_objects/789'}
-                json_object3 = {'uri': '/repositories/0/digital_objects/789',
-                                'file_versions': [{'file_uri':
-                                                  'old_content_link'}]}
-                json_object4 = {'status': 'Updated'}
-                json_object5 = {'status': 'Created', 'uri':
+                do_json = {'uri': '/repositories/0/digital_objects/789',
+                           'file_versions': [{'file_uri':
+                                             'old_content_link'}]}
+                ao_upd_json = {'status': 'Updated'}
+                ao_crtd_json = {'status': 'Created', 'uri':
                                 '/repositories/0/archival_objects/123'}
                 base_url = 'mock://mock.mock/users/test/login'
                 do_url = '/repositories/0/digital_objects'
                 item_url = '/repositories/0/digital_objects/789'
                 arch_obj_url = '/repositories/0/archival_objects'
-                m.post(base_url, json=json_object1)
-                m.post(do_url, json=json_object2)
-                m.get(item_url, json=json_object3)
-                m.post(item_url, json=json_object4)
-                m.post(arch_obj_url, json=json_object5)
+                m.post(base_url, json=session_json)
+                m.post(do_url, json=do_crtd_json)
+                m.get(item_url, json=do_json)
+                m.post(item_url, json=ao_upd_json)
+                m.post(arch_obj_url, json=ao_crtd_json)
                 result = runner.invoke(main,
                                        ['--url', 'mock://mock.mock',
                                         '--username', 'test',
@@ -193,26 +192,26 @@ def test_newdigobjs(runner):
                                 + ['AO Title']
                                 + ['mock://example.com/handle/111.1111'])
 
-                json_object1 = {'session': 'abcdefg1234567'}
-                json_object2 = {'status': 'Created', 'uri':
+                session_json = {'session': 'abcdefg1234567'}
+                do_crtd_json = {'status': 'Created', 'uri':
                                 '/repositories/0/digital_objects/789'}
-                json_object3 = {'uri': '/repositories/0/digital_objects/789',
-                                'file_versions': [
+                do_json = {'uri': '/repositories/0/digital_objects/789',
+                           'file_versions': [
                                         {'file_uri':
                                          'mock://example.com/handle/111.1111'}]
-                                }
-                json_object4 = {'status': 'Updated'}
-                json_object5 = {'status': 'Updated', 'uri':
-                                '/repositories/0/archival_objects/123'}
+                           }
+                do_upd_json = {'status': 'Updated'}
+                ao_upd_json = {'status': 'Updated', 'uri':
+                               '/repositories/0/archival_objects/123'}
                 base_url = 'mock://mock.mock/users/test/login'
                 do_url = '/repositories/0/digital_objects'
                 item_url = '/repositories/0/digital_objects/789'
                 arch_obj_url = '/repositories/0/digital_objects'
-                m.post(base_url, json=json_object1)
-                m.post(do_url, json=json_object2)
-                m.get(item_url, json=json_object3)
-                m.post(item_url, json=json_object4)
-                m.post(arch_obj_url, json=json_object5)
+                m.post(base_url, json=session_json)
+                m.post(do_url, json=do_crtd_json)
+                m.get(item_url, json=do_json)
+                m.post(item_url, json=do_upd_json)
+                m.post(arch_obj_url, json=ao_upd_json)
                 result = runner.invoke(main,
                                        ['--url', 'mock://mock.mock',
                                         '--username', 'test',
@@ -227,17 +226,17 @@ def test_newdigobjs(runner):
 def test_report(runner):
     """Test report command."""
     with requests_mock.Mocker() as m:
-        json_object1 = {'session': 'abcdefg1234567'}
-        json_object2 = {'id_0': 'AB', 'id_1': '123', 'title': 'Test title',
-                        'uri': '/repositories/0/resources/1234', 'notes':
+        session_json = {'session': 'abcdefg1234567'}
+        res_json = {'id_0': 'AB', 'id_1': '123', 'title': 'Test title',
+                    'uri': '/repositories/0/resources/1234', 'notes':
                         [{'type': 'acqinfo', 'subnotes': [{'content':
                          'test value'}]}]}
         base_url = 'mock://mock.mock/users/test/login'
         ids_url = '/repositories/0/resources?all_ids=true'
         item_url = '/repositories/0/resources/1234'
-        m.post(base_url, json=json_object1)
+        m.post(base_url, json=session_json)
         m.get(ids_url, json=['1234'])
-        m.get(item_url, json=json_object2)
+        m.get(item_url, json=res_json)
         result = runner.invoke(main,
                                ['--url', 'mock://mock.mock',
                                 '--username', 'test',
@@ -259,16 +258,16 @@ def test_updatedigobj(runner):
                 writer.writerow(['do_uri'] + ['link'])
                 writer.writerow(['/repositories/0/digital_objects/1234'] +
                                 ['new_content_link'])
-            json_object1 = {'session': 'abcdefg1234567'}
-            json_object2 = {'uri': '/repositories/0/digital_objects/1234',
-                            'file_versions': [{'file_uri':
-                                              'old_content_link'}]}
-            json_object3 = {'status': 'Updated'}
+            session_json = {'session': 'abcdefg1234567'}
+            do_json = {'uri': '/repositories/0/digital_objects/1234',
+                       'file_versions': [{'file_uri':
+                                         'old_content_link'}]}
+            do_upd_json = {'status': 'Updated'}
             base_url = 'mock://mock.mock/users/test/login'
             item_url = '/repositories/0/digital_objects/1234'
-            m.post(base_url, json=json_object1)
-            m.get(item_url, json=json_object2)
-            m.post(item_url, json=json_object3)
+            m.post(base_url, json=session_json)
+            m.get(item_url, json=do_json)
+            m.post(item_url, json=do_upd_json)
             result = runner.invoke(main,
                                    ['--url', 'mock://mock.mock',
                                     '--username', 'test',
@@ -289,16 +288,16 @@ def test_updaterecords(runner):
                 writer.writerow(['uri'] + ['accessrestrict'])
                 writer.writerow(['/repositories/0/archival_objects/1234'] +
                                 ['New note content'])
-                json_object1 = {'session': 'abcdefg1234567'}
-                json_object2 = {'uri': '/repositories/0/archival_objects/1234',
-                                'notes': [{'subnotes': [{'content':
-                                                        'Old note content'}]}]}
-                json_object3 = {'status': 'Updated'}
+                session_json = {'session': 'abcdefg1234567'}
+                ao_json = {'uri': '/repositories/0/archival_objects/1234',
+                           'notes': [{'subnotes': [{'content':
+                                                   'Old note content'}]}]}
+                ao_upd_json = {'status': 'Updated'}
                 base_url = 'mock://mock.mock/users/test/login'
                 item_url = '/repositories/0/archival_objects/1234'
-                m.post(base_url, json=json_object1)
-                m.get(item_url, json=json_object2)
-                m.post(item_url, json=json_object3)
+                m.post(base_url, json=session_json)
+                m.get(item_url, json=ao_json)
+                m.post(item_url, json=ao_upd_json)
                 result = runner.invoke(main,
                                        ['--url', 'mock://mock.mock',
                                         '--username', 'test',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,21 +59,6 @@ def test_post_new_record(as_ops):
         assert resp['status'] == 'Created'
 
 
-def test_search(as_ops):
-    """Test search method."""
-    with requests_mock.Mocker() as m:
-        string = 'string'
-        repo_id = '0'
-        rec_type = 'resource'
-        field = 'acqinfo'
-        json_object = [{'uri': '1234'}]
-        url = f'/repositories/{repo_id}/search?'
-        m.get(url, json=json_object)
-        results = as_ops.search(string, repo_id, rec_type, field)
-        for result in results:
-            assert result == json_object[0]['uri']
-
-
 def test_save_record(as_ops, caplog):
     """Test post_record method."""
     caplog.set_level(logging.INFO)
@@ -87,6 +72,21 @@ def test_save_record(as_ops, caplog):
         as_ops.save_record(rec_obj, dry_run)
         message = json.loads(caplog.messages[0])['event']
         assert message == json_object
+
+
+def test_search(as_ops):
+    """Test search method."""
+    with requests_mock.Mocker() as m:
+        string = 'string'
+        repo_id = '0'
+        rec_type = 'resource'
+        field = 'acqinfo'
+        json_object = [{'uri': '1234'}]
+        url = f'/repositories/{repo_id}/search?'
+        m.get(url, json=json_object)
+        results = as_ops.search(string, repo_id, rec_type, field)
+        for result in results:
+            assert result == json_object[0]['uri']
 
 
 def test_record_is_modified():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,8 +21,8 @@ def test_get_all_records(as_ops):
     """Test get_all_records method."""
     with requests_mock.Mocker() as m:
         endpoint = '/repositories/0/resources'
-        json_object = [1, 2, 3, 4]
-        m.get('/repositories/0/resources?all_ids=true', json=json_object)
+        ids_json = [1, 2, 3, 4]
+        m.get('/repositories/0/resources?all_ids=true', json=ids_json)
         ids = as_ops.get_all_records(endpoint)
         assert ids == [1, 2, 3, 4]
 
@@ -31,9 +31,9 @@ def test_get_arch_objs_for_resource(as_ops):
     """Test get_arch_objs_for_resource method."""
     with requests_mock.Mocker() as m:
         resource = '/repositories/2/resources/423'
-        json_object = {'record_uri': '/archival_objects/1234', 'children':
-                       [{'record_uri': '/archival_objects/5678'}]}
-        m.get(f'{resource}/tree', json=json_object)
+        tree_json = {'record_uri': '/archival_objects/1234', 'children':
+                     [{'record_uri': '/archival_objects/5678'}]}
+        m.get(f'{resource}/tree', json=tree_json)
         arch_objlist = as_ops.get_arch_objs_for_resource(resource)
         assert '/archival_objects/5678' in arch_objlist
 
@@ -42,19 +42,19 @@ def test_get_record(as_ops):
     """Test get_record method."""
     with requests_mock.Mocker() as m:
         uri = '/repositories/2/resources/423'
-        json_object = {'jsonmodel_type': 'resource'}
-        m.get(uri, json=json_object)
+        rec_json = {'jsonmodel_type': 'resource'}
+        m.get(uri, json=rec_json)
         response = as_ops.get_record(uri)
-        assert response == json_object
+        assert response == rec_json
 
 
 def test_post_new_record(as_ops):
     """Test post_new_record method."""
     with requests_mock.Mocker() as m:
         endpoint = '/repositories/0/resources'
-        json_object = {'status': 'Created'}
+        crtd_json = {'status': 'Created'}
         rec_obj = {'title': 'Test title'}
-        m.post(endpoint, json=json_object)
+        m.post(endpoint, json=crtd_json)
         resp = as_ops.post_new_record(rec_obj, endpoint)
         assert resp['status'] == 'Created'
 
@@ -67,11 +67,11 @@ def test_save_record(as_ops, caplog):
         uri = '/repositories/2/resources/423'
         dry_run = 'False'
         rec_obj['uri'] = uri
-        json_object = {'post': 'Success'}
-        m.post(uri, json=json_object)
+        upd_json = {'post': 'Success'}
+        m.post(uri, json=upd_json)
         as_ops.save_record(rec_obj, dry_run)
         message = json.loads(caplog.messages[0])['event']
-        assert message == json_object
+        assert message == upd_json
 
 
 def test_search(as_ops):
@@ -81,12 +81,12 @@ def test_search(as_ops):
         repo_id = '0'
         rec_type = 'resource'
         field = 'acqinfo'
-        json_object = [{'uri': '1234'}]
+        search_json = [{'uri': '1234'}]
         url = f'/repositories/{repo_id}/search?'
-        m.get(url, json=json_object)
+        m.get(url, json=search_json)
         results = as_ops.search(string, repo_id, rec_type, field)
         for result in results:
-            assert result == json_object[0]['uri']
+            assert result == search_json[0]['uri']
 
 
 def test_record_is_modified():

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,71 @@
+import csv
+import json
+import logging
+
+from asnake.client import ASnakeClient
+from click.testing import CliRunner
+import pytest
+import requests_mock
+
+from asaps import models, workflows
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def as_ops():
+    client = ASnakeClient(baseurl='mock://example.com', username='test',
+                          password='test')
+    as_ops = models.AsOperations(client)
+    return as_ops
+
+
+def test_export_metadata(as_ops):
+    """Test export_metadata method."""
+    with requests_mock.Mocker() as m:
+        resource = '/repositories/0/resources/423'
+        repo_id = '0'
+        field = 'ref_id'
+        ao_uri = '/repositories/0/archival_objects/1234'
+        json_object_1 = {'record_uri': ao_uri}
+        json_object_2 = {'uri': ao_uri, 'ref_id':
+                         'a2b2c2', 'display_string': 'Sample Title'}
+        m.get(f'{resource}/tree', json=json_object_1)
+        m.get(ao_uri, json=json_object_2)
+        report_dicts = workflows.export_metadata(as_ops, resource, field,
+                                                 repo_id)
+        for report_dict in report_dicts:
+            assert report_dict['uri'] == ao_uri
+            assert report_dict['title'] == 'Sample Title'
+            assert report_dict['file_identifier'] == 'a2b2c2'
+
+
+def test_create_new_dig_objs(as_ops, caplog, runner):
+    """Test create_new_dig_objs method."""
+    caplog.set_level(logging.INFO)
+    with requests_mock.Mocker() as m:
+        with runner.isolated_filesystem():
+            with open('metadata.csv', 'w') as f:
+                writer = csv.writer(f)
+                writer.writerow(['uri'] + ['link'])
+                writer.writerow(['/repositories/0/archival_objects/1234'] +
+                                ['mock://example.com/handle/111.1111'])
+            ao_uri = 'mock://example.com/repositories/0/archival_objects/1234'
+            dos_uri = 'mock://example.com/repositories/0/digital_objects'
+            do_uri = '/repositories/0/digital_objects/5678'
+            json_object_1 = {'uri': '/repositories/0/archival_objects/1234',
+                             'display_string': 'Sample Title',
+                             'instances': []}
+            json_object_2 = {'post': 'Success', 'uri': do_uri}
+            json_object_3 = {'post': 'Success'}
+            m.get(ao_uri, json=json_object_1)
+            m.post(dos_uri, json=json_object_2)
+            m.post(ao_uri, json=json_object_3)
+            workflows.create_new_dig_objs(as_ops, 'metadata.csv', '0')
+            message_1 = json.loads(caplog.messages[1])['event']
+            message_2 = json.loads(caplog.messages[2])['event']
+            assert message_1 == json_object_2
+            assert message_2 == json_object_3

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -26,15 +26,16 @@ def as_ops():
 def test_export_metadata(as_ops):
     """Test export_metadata method."""
     with requests_mock.Mocker() as m:
-        resource = '/repositories/0/resources/423'
+        resource = '423'
         repo_id = '0'
         field = 'ref_id'
         ao_uri = '/repositories/0/archival_objects/1234'
-        json_object_1 = {'record_uri': ao_uri}
-        json_object_2 = {'uri': ao_uri, 'ref_id':
-                         'a2b2c2', 'display_string': 'Sample Title'}
-        m.get(f'{resource}/tree', json=json_object_1)
-        m.get(ao_uri, json=json_object_2)
+        tree_json = {'record_uri': ao_uri}
+        ao_json = {'uri': ao_uri, 'ref_id': 'a2b2c2', 'display_string':
+                   'Sample Title'}
+        m.get(f'/repositories/{repo_id}/resources/{resource}/tree',
+              json=tree_json)
+        m.get(ao_uri, json=ao_json)
         report_dicts = workflows.export_metadata(as_ops, resource, field,
                                                  repo_id)
         for report_dict in report_dicts:
@@ -56,16 +57,15 @@ def test_create_new_dig_objs(as_ops, caplog, runner):
             ao_uri = 'mock://example.com/repositories/0/archival_objects/1234'
             dos_uri = 'mock://example.com/repositories/0/digital_objects'
             do_uri = '/repositories/0/digital_objects/5678'
-            json_object_1 = {'uri': '/repositories/0/archival_objects/1234',
-                             'display_string': 'Sample Title',
-                             'instances': []}
-            json_object_2 = {'post': 'Success', 'uri': do_uri}
-            json_object_3 = {'post': 'Success'}
-            m.get(ao_uri, json=json_object_1)
-            m.post(dos_uri, json=json_object_2)
-            m.post(ao_uri, json=json_object_3)
+            ao_json = {'uri': '/repositories/0/archival_objects/1234',
+                       'display_string': 'Sample Title', 'instances': []}
+            do_upd_json = {'post': 'Success', 'uri': do_uri}
+            ao_upd_json = {'post': 'Success'}
+            m.get(ao_uri, json=ao_json)
+            m.post(dos_uri, json=do_upd_json)
+            m.post(ao_uri, json=ao_upd_json)
             workflows.create_new_dig_objs(as_ops, 'metadata.csv', '0')
             message_1 = json.loads(caplog.messages[1])['event']
             message_2 = json.loads(caplog.messages[2])['event']
-            assert message_1 == json_object_2
-            assert message_2 == json_object_3
+            assert message_1 == do_upd_json
+            assert message_2 == ao_upd_json

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py37,flake8,safety,coverage
+envlist = py38,flake8,safety,coverage
 skipsdist = True
 
 [testenv]
-basepython = python3.7
+basepython = python3.8
 deps =
   pipenv
   {coverage,coveralls}: pytest-cov


### PR DESCRIPTION
#### What does this PR do?
This PR begins to shifts code in the `cli` module to a new 'workflows` module. This is intended to simplify its reuse in other applications as I explore integrations between ArchivesSpace and Dome. This PR only includes this shift for the new `metadata` and `newdigobjs` commands but I will be circling back to refactor the other commands after these initial changes are reviewed. The `workflows` currently contains a function for exporting a specific set of Archival Object metadata and a function for creating new Digital Objects based on a list of Archival Objects URIs and relevant links. Corresponding tests are also included for both commands and functions.

There are also minor updates related to the upgrade from Python 3.7 to 3.8 and for making timestamped suffixes optional on CSVs created from log files.

#### Includes new or updated dependencies?
YES
