### PR TITLE
move mocks from test_models to conftest & add CSV unit test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,29 @@
 import logging
+
+from click.testing import CliRunner
 import pytest
+import requests_mock
 import structlog
+
+
+@pytest.fixture(autouse=True)
+def as_mock():
+    with requests_mock.Mocker() as m:
+        ids_json = [1, 2, 3, 4]
+        m.get('/repositories/0/resources?all_ids=true',
+              json=ids_json)
+        rec_json = {'jsonmodel_type': 'resource'}
+        m.get('/repositories/2/resources/423', json=rec_json)
+        upd_json = {'post': 'Success'}
+        m.post('/repositories/0/resources/423', json=upd_json)
+        tree_json = {'record_uri': '/archival_objects/1234', 'children':
+                     [{'record_uri': '/archival_objects/5678'}]}
+        m.get('/repositories/2/resources/423/tree', json=tree_json)
+        crtd_json = {'status': 'Created'}
+        m.post('/repositories/0/resources', json=crtd_json)
+        search_json = [{'uri': '1234'}]
+        m.get('/repositories/0/search?', json=search_json)
+        yield m
 
 
 @pytest.fixture(autouse=True, scope='session')
@@ -9,3 +32,8 @@ def logger():
     logging.basicConfig(format="%(message)s",
                         handlers=[logging.StreamHandler()], level=logging.INFO)
     return logger
+
+
+@pytest.fixture(autouse=True)
+def runner():
+    return CliRunner()

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -93,19 +93,6 @@ def test_create_date():
     assert date['label'] == label
 
 
-def test_create_date():
-    """Test create_date function."""
-    expression = ''
-    begin = '1902'
-    end = '2049'
-    certainty = ''
-    label = 'existence'
-    date = records.create_date(begin, end, expression, certainty, label)
-    assert date['begin'] == begin
-    assert date['end'] == end
-    assert date['label'] == label
-
-
 def test_create_dig_obj():
     """Test create_dig_obj method."""
     title = 'Test title'


### PR DESCRIPTION
#### What does this PR do?
Shifts testing fixtures from `test_models.py` to `conftest.py`. After this is reviewed, I will do a similar shift for `test_cli.py` and `test_workflows.py`.

Also finally adds a unit test for the `create_csv_from_log` function and deletes a duplicate test in `test_records.py`.

#### Includes new or updated dependencies?
NO
