### PR TITLE
csv fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ data/*
 !data/.keep
 .profile
 *.csv
+!tests/fixtures/*.csv
 *.json
 local/*
 *.xml

--- a/asaps/cli.py
+++ b/asaps/cli.py
@@ -172,9 +172,12 @@ def metadata(ctx, resource, file_identifier, repo_id):
 @click.pass_context
 @click.option('-m', '--metadata_csv', prompt='Enter the metadata CSV file',
               help='The metadata CSV file to use.')
+@click.option('-o', '--output_path', prompt='Enter the output path',
+              default='', help='The path of the output files, include '
+              '/ at the end of the path')
 @click.option('-p', '--match_point', prompt='Enter the match point',
               help='The match point to be used in the new record report.')
-def newagents(ctx, metadata_csv, match_point):
+def newagents(ctx, metadata_csv, output_path, match_point):
     """Creates new agent records based on a CSV file."""
     as_ops = ctx.obj['as_ops']
     start_time = ctx.obj['start_time']
@@ -213,7 +216,8 @@ def newagents(ctx, metadata_csv, match_point):
             agent_endpoint = models.create_endpoint(agent_type)
             agent_resp = as_ops.post_new_record(agent_rec, agent_endpoint)
             new_rec_data[row[match_point]] = agent_resp['uri']
-        models.create_new_rec_report(new_rec_data, metadata_csv)
+        models.create_new_rec_report(new_rec_data,
+                                     f'{output_path}newagents')
     models.elapsed_time(start_time, 'Total runtime:')
     models.create_csv_from_log('agents', log_suffix)
 

--- a/asaps/models.py
+++ b/asaps/models.py
@@ -160,8 +160,8 @@ def create_endpoint(rec_type, repo_id=''):
 
 
 def create_new_rec_report(new_rec_data, file_name):
-    """Creates ingest report of handles and DOS links."""
-    with open(f'{file_name}-new-recs.csv', 'w') as writecsv:
+    """Creates a report of match points and ArchivesSpace URIs."""
+    with open(f'{file_name}.csv', 'w') as writecsv:
         writer = csv.writer(writecsv)
         writer.writerow(['match_point'] + ['uri'])
         for match_point, uri in new_rec_data.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,13 @@ def logger():
     return logger
 
 
+@pytest.fixture()
+def output_dir(tmp_path):
+    output_dir = tmp_path / 'output'
+    output_dir.mkdir()
+    return str(f'{output_dir}/')
+
+
 @pytest.fixture(autouse=True)
 def runner():
     return CliRunner()

--- a/tests/fixtures/deletefield.csv
+++ b/tests/fixtures/deletefield.csv
@@ -1,0 +1,2 @@
+uri
+/repositories/0/archival_objects/1234

--- a/tests/fixtures/newagents.csv
+++ b/tests/fixtures/newagents.csv
@@ -1,0 +1,2 @@
+search,agent_type,primary_name,sort_name,authority_id,rest_of_name,fuller_form,title,prefix,suffix,dates,expression,begin,end,certainty,label
+"Smith, J.",people,Smith,"Smith, John, 1902-2049",mock://mock.mock/123,John,,,,,1902-2049,1902,2049,,existence

--- a/tests/fixtures/newarchobjs-agents.csv
+++ b/tests/fixtures/newarchobjs-agents.csv
@@ -1,0 +1,2 @@
+match_point,uri
+"Smith, J.",agents/people/1234

--- a/tests/fixtures/newarchobjs.csv
+++ b/tests/fixtures/newarchobjs.csv
@@ -1,0 +1,2 @@
+resource,parent_uri,title,publisher,link,abstract,top_container_1,top_container_2,child_type,child_indicator,authors,begin,end,expression,certainty,label
+/repositories/0/resources/1234,/repositories/0/archival_objects/456,Test title,/agents/corporate_entities/12,http://dos.com/123,This is an abstract,/repositories/0/top_containers/123,/repositories/0/top_containers/456,reel,2,"[""Smith, J.""]",,,,,

--- a/tests/fixtures/newdigobjs.csv
+++ b/tests/fixtures/newdigobjs.csv
@@ -1,0 +1,2 @@
+uri,display_string,link
+/repositories/0/archival_objects/1234,AO Title,mock://example.com/handle/111.1111

--- a/tests/fixtures/updatedigobj.csv
+++ b/tests/fixtures/updatedigobj.csv
@@ -1,0 +1,2 @@
+do_uri,link
+/repositories/0/digital_objects/5678,new_content_link

--- a/tests/fixtures/updaterecords.csv
+++ b/tests/fixtures/updaterecords.csv
@@ -1,0 +1,2 @@
+uri,accessrestrict
+/repositories/0/archival_objects/1234,New note content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,25 +1,19 @@
-import csv
-
 from asaps.cli import main
 
 
 def test_deletefield(runner):
     """Test updaterecords command."""
-    with runner.isolated_filesystem():
-        with open('metadata.csv', 'w') as f:
-            writer = csv.writer(f)
-            writer.writerow(['uri'])
-            writer.writerow(['/repositories/0/archival_objects/1234'])
-            result = runner.invoke(main,
-                                   ['--url', 'mock://example.com',
-                                    '--username', 'test',
-                                    '--password', 'testpass',
-                                    'deletefield',
-                                    '--dry_run', 'False',
-                                    '--metadata_csv', 'metadata.csv',
-                                    '--field', 'accessrestrict'
-                                    ])
-        assert result.exit_code == 0
+    result = runner.invoke(main,
+                           ['--url', 'mock://example.com',
+                            '--username', 'test',
+                            '--password', 'testpass',
+                            'deletefield',
+                            '--dry_run', 'False',
+                            '--metadata_csv',
+                            'tests/fixtures/deletefield.csv',
+                            '--field', 'accessrestrict'
+                            ])
+    assert result.exit_code == 0
 
 
 def test_find(runner):
@@ -50,85 +44,43 @@ def test_metadata(runner):
     assert result.exit_code == 0
 
 
-def test_newagents(runner):
+def test_newagents(runner, output_dir):
     """Test newagents command."""
-    with runner.isolated_filesystem():
-        with open('metadata.csv', 'w') as f:
-            writer = csv.writer(f)
-            writer.writerow(['search'] + ['agent_type'] + ['primary_name']
-                            + ['sort_name'] + ['authority_id']
-                            + ['rest_of_name'] + ['fuller_form']
-                            + ['title'] + ['prefix'] + ['suffix']
-                            + ['dates'] + ['expression'] + ['begin']
-                            + ['end'] + ['certainty'] + ['label'])
-            writer.writerow(['Smith, J.'] + ['people'] + ['Smith']
-                            + ['Smith, John, 1902-2049']
-                            + ['mock://mock.mock/123'] + ['John']
-                            + [''] + [''] + [''] + [''] + ['1902-2049']
-                            + ['1902'] + ['2049'] + [''] + ['existence'])
-        result = runner.invoke(main,
-                               ['--url', 'mock://example.com',
-                                '--username', 'test',
-                                '--password', 'testpass',
-                                'newagents', '--metadata_csv',
-                                'metadata.csv', '--match_point', 'search'])
-        assert result.exit_code == 0
+    result = runner.invoke(main,
+                           ['--url', 'mock://example.com',
+                            '--username', 'test',
+                            '--password', 'testpass',
+                            'newagents',
+                            '--metadata_csv', 'tests/fixtures/newagents.csv',
+                            '--output_path', output_dir,
+                            '--match_point', 'search'])
+    assert result.exit_code == 0
 
 
 def test_newarchobjs(runner):
     """Test newarchobjs command."""
-    with runner.isolated_filesystem():
-        with open('agents.csv', 'w') as f:
-            writer = csv.writer(f)
-            writer.writerow(['match_point'] + ['uri'])
-            writer.writerow(['Smith, J.'] + ['agents/people/123'])
-            with open('metadata.csv', 'w') as f2:
-                writer2 = csv.writer(f2)
-                writer2.writerow(['resource'] + ['parent_uri'] + ['title']
-                                 + ['publisher'] + ['link'] + ['abstract']
-                                 + ['top_container_1']
-                                 + ['top_container_2'] + ['child_type']
-                                 + ['child_indicator'] + ['authors']
-                                 + ['begin'] + ['end'] + ['expression']
-                                 + ['certainty'] + ['label'])
-                writer2.writerow(['/repositories/0/resources/123']
-                                 + ['/repositories/0/archival_objects/456']
-                                 + ['Test title']
-                                 + ['/agents/corporate_entities/12']
-                                 + ['http://dos.com/123']
-                                 + ['This is an abstract']
-                                 + ['/repositories/0/top_containers/123']
-                                 + ['/repositories/0/top_containers/456']
-                                 + ['reel'] + ['2'] + ['["Smith, J."]']
-                                 + [''] + [''] + [''] + [''] + [''])
-            result = runner.invoke(main,
-                                   ['--url', 'mock://example.com',
-                                    '--username', 'test',
-                                    '--password', 'testpass',
-                                    'newarchobjs',
-                                    '--repo_id', '0',
-                                    '--metadata_csv', 'metadata.csv',
-                                    '--agent_file', 'agents.csv'])
-        assert result.exit_code == 0
+    result = runner.invoke(main,
+                           ['--url', 'mock://example.com',
+                            '--username', 'test',
+                            '--password', 'testpass',
+                            'newarchobjs',
+                            '--repo_id', '0',
+                            '--metadata_csv', 'tests/fixtures/newarchobjs.csv',
+                            '--agent_file',
+                            'tests/fixtures/newarchobjs-agents.csv'])
+    assert result.exit_code == 0
 
 
 def test_newdigobjs(runner):
     """Test newdigobjs command"""
-    with runner.isolated_filesystem():
-        with open('ingest.csv', 'w') as f:
-            writer = csv.writer(f)
-            writer.writerow(['uri'] + ['display_string'] + ['link'])
-            writer.writerow(['/repositories/0/archival_objects/123']
-                            + ['AO Title']
-                            + ['mock://example.com/handle/111.1111'])
-            result = runner.invoke(main,
-                                   ['--url', 'mock://mock.mock',
-                                    '--username', 'test',
-                                    '--password', 'testpass',
-                                    'newdigobjs',
-                                    '--metadata_csv', 'ingest.csv',
-                                    '--repo_id', '0'])
-        assert result.exit_code == 0
+    result = runner.invoke(main,
+                           ['--url', 'mock://mock.mock',
+                            '--username', 'test',
+                            '--password', 'testpass',
+                            'newdigobjs',
+                            '--metadata_csv', 'tests/fixtures/newdigobjs.csv',
+                            '--repo_id', '0'])
+    assert result.exit_code == 0
 
 
 def test_report(runner):
@@ -146,37 +98,25 @@ def test_report(runner):
 
 def test_updatedigobj(runner):
     """Test updatedigobj command."""
-    with runner.isolated_filesystem():
-        with open('metadata.csv', 'w') as f:
-            writer = csv.writer(f)
-            writer.writerow(['do_uri'] + ['link'])
-            writer.writerow(['/repositories/0/digital_objects/5678'] +
-                            ['new_content_link'])
-        result = runner.invoke(main,
-                               ['--url', 'mock://example.com',
-                                '--username', 'test',
-                                '--password', 'testpass',
-                                'updatedigobj',
-                                '--dry_run', 'False',
-                                '--metadata_csv', 'metadata.csv'])
-        assert result.exit_code == 0
+    result = runner.invoke(main,
+                           ['--url', 'mock://example.com',
+                            '--username', 'test',
+                            '--password', 'testpass',
+                            'updatedigobj',
+                            '--dry_run', 'False',
+                            '--metadata_csv', 'tests/fixtures/updatedigobj.csv'])
+    assert result.exit_code == 0
 
 
 def test_updaterecords(runner):
     """Test updaterecords command."""
-    with runner.isolated_filesystem():
-        with open('metadata.csv', 'w') as f:
-            writer = csv.writer(f)
-            writer.writerow(['uri'] + ['accessrestrict'])
-            writer.writerow(['/repositories/0/archival_objects/1234'] +
-                            ['New note content'])
-            result = runner.invoke(main,
-                                   ['--url', 'mock://example.com',
-                                    '--username', 'test',
-                                    '--password', 'testpass',
-                                    'updaterecords',
-                                    '--dry_run', 'False',
-                                    '--metadata_csv', 'metadata.csv',
-                                    '--field', 'accessrestrict',
-                                    '--rpl_value_col', 'accessrestrict'])
-        assert result.exit_code == 0
+    result = runner.invoke(main,
+                           ['--url', 'mock://example.com',
+                            '--username', 'test',
+                            '--password', 'testpass',
+                            'updaterecords',
+                            '--dry_run', 'False',
+                            '--metadata_csv', 'tests/fixtures/updaterecords.csv',
+                            '--field', 'accessrestrict',
+                            '--rpl_value_col', 'accessrestrict'])
+    assert result.exit_code == 0

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,4 +1,3 @@
-import csv
 import json
 import logging
 
@@ -9,17 +8,11 @@ from asaps import workflows
 def test_create_new_dig_objs(as_ops, caplog, runner):
     """Test create_new_dig_objs method."""
     caplog.set_level(logging.INFO)
-    with runner.isolated_filesystem():
-        with open('metadata.csv', 'w') as f:
-            writer = csv.writer(f)
-            writer.writerow(['uri'] + ['link'])
-            writer.writerow(['/repositories/0/archival_objects/1234'] +
-                            ['mock://example.com/handle/111.1111'])
-        workflows.create_new_dig_objs(as_ops, 'metadata.csv', '0')
-        message_1 = json.loads(caplog.messages[1])['event']
-        message_2 = json.loads(caplog.messages[2])['event']
-        assert message_1['uri'] == '/repositories/0/digital_objects/5678'
-        assert message_2['post'] == 'Success'
+    workflows.create_new_dig_objs(as_ops, 'tests/fixtures/newdigobjs.csv', '0')
+    message_1 = json.loads(caplog.messages[1])['event']
+    message_2 = json.loads(caplog.messages[2])['event']
+    assert message_1['uri'] == '/repositories/0/digital_objects/5678'
+    assert message_2['post'] == 'Success'
 
 
 def test_export_metadata(as_ops):


### PR DESCRIPTION
#### What does this PR do?

- Adds CSV fixtures for several tests and  removes `runner.isolated_filesystem` from those tests.
- Updates `newagents` command to add an `output_path` option for the resulting CSV file and adds an `output_dir` test fixture.
- Updates an incorrect docstring for `create_new_rec_report`.

#### Includes new or updated dependencies?
NO
